### PR TITLE
Add DRATS test case for UAA backup/restore

### DIFF
--- a/testcases/cf_uaa_testcase.go
+++ b/testcases/cf_uaa_testcase.go
@@ -1,0 +1,51 @@
+package testcases
+
+import (
+	. "github.com/cloudfoundry-incubator/disaster-recovery-acceptance-tests/common"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+type CfUaaTestCase struct {
+	uniqueTestID string
+	testPassword string
+}
+
+func NewCfUaaTestCase() *CfUaaTestCase {
+	id := RandomStringNumber()
+	password := RandomStringNumber()
+	return &CfUaaTestCase{uniqueTestID: id, testPassword: password}
+}
+
+func login(config Config, username, password string) {
+	RunCommandSuccessfully("cf login --skip-ssl-validation -a", config.DeploymentToBackup.ApiUrl, "-u", username, "-p", password)
+}
+
+func (tc *CfUaaTestCase) BeforeBackup(config Config) {
+	By("we create a user and can login")
+	login(config, config.DeploymentToBackup.AdminUsername, config.DeploymentToBackup.AdminPassword)
+	RunCommandSuccessfully("cf create-user ", tc.uniqueTestID, tc.testPassword)
+	login(config, tc.uniqueTestID, tc.testPassword)
+	RunCommandSuccessfully("cf logout")
+}
+
+func (tc *CfUaaTestCase) AfterBackup(config Config) {
+	By("we delete the user and verify")
+	login(config, config.DeploymentToBackup.AdminUsername, config.DeploymentToBackup.AdminPassword)
+	RunCommandSuccessfully("cf delete-user ", tc.uniqueTestID, "-f")
+	RunCommandSuccessfully("cf logout")
+	result := RunCommand("cf login --skip-ssl-validation -a", config.DeploymentToBackup.ApiUrl, "-u", tc.uniqueTestID, "-p", "password")
+	Expect(result.ExitCode()).To(Equal(1))
+}
+
+func (tc *CfUaaTestCase) AfterRestore(config Config) {
+	By("we can login again")
+	login(config, tc.uniqueTestID, tc.testPassword)
+}
+
+func (tc *CfUaaTestCase) Cleanup(config Config) {
+	By("We delete the user")
+	login(config, config.DeploymentToBackup.AdminUsername, config.DeploymentToBackup.AdminPassword)
+	RunCommandSuccessfully("cf delete-user ", tc.uniqueTestID, "-f")
+}
+

--- a/testcases/testcase_helper.go
+++ b/testcases/testcase_helper.go
@@ -8,4 +8,5 @@ func OpenSourceTestCases() []runner.TestCase {
 		NewCfAppTestCase(),
 		NewCfUaaTestCase(),
 	}
+	
 }

--- a/testcases/testcase_helper.go
+++ b/testcases/testcase_helper.go
@@ -6,5 +6,6 @@ func OpenSourceTestCases() []runner.TestCase {
 	return []runner.TestCase{
 		NewAppUptimeTestCase(),
 		NewCfAppTestCase(),
+		NewCfUaaTestCase(),
 	}
 }


### PR DESCRIPTION
UAA with BBR Support is out in [v52](http://bosh.io/releases/github.com/cloudfoundry/uaa-release?version=52)

Reference: https://www.pivotaltracker.com/story/show/151624690

Thanks for submitting a PR to DRATS.

1. Testing: UAA
1. Added testcase
1. Validated against: cf-deployment/develop on this day. bbr opsfile modified to colocate [`bbr-uaadb`](https://github.com/cloudfoundry/uaa-release/tree/develop/jobs) job from `uaa-release`
1. Yes, this PR relies on functionality not yet released. This PR will be updated when it is.

## Checklist

Please provide the following information:

- [x] What component are you testing?
- [x] Have you created a TestCase and added it to the list of cases to be run?
- [x] Have you manually validated your TestCase against a deployed Cloud Foundry? If so, which version?
- [x] Does this change rely on a particular version of CF release?
- [x] Are you available for a cross-team pair to help troubleshoot your PR?

### Do you have any other useful information for us?
The [`testsuite`](https://github.com/cloudfoundry-incubator/disaster-recovery-acceptance-tests/blob/402dfad4b437ea43b021ed89405f968b6a5ceb44/testcases/testcase_helper.go#L6-L9) is not really a suite. If the first test fails, the other tests in the suite are not run. 
This delays the feedback loop for failed tests. Adding `-keepGoing` to ginkgo did not solve that problem.

The test suite itself does not document what additional steps are required to make cf-deployment pass. An opsfile should be referenced.

UAA adds the `bbr-uaadb` job to the backup-and-restore-sdk VM
```
      jobs:
      - name: bbr-uaadb
        release: uaa
      - name: database-backup-restorer
        release: backup-and-restore-sdk
```

We're on the #pcf-backup-restore Slack channel if you need us.