### PR TITLE
Test that bbr restores encrypted fields in CAPI

### DIFF
--- a/run-drats.sh
+++ b/run-drats.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+# ENV
+: "${BOSH_CLIENT:?}"
+: "${BOSH_CLIENT_SECRET:?}"
+: "${BOSH_CA_CERT:?}"
+: "${BOSH_GW_HOST:?}"
+: "${BOSH_GW_USER:?}"
+: "${BOSH_GW_PRIVATE_KEY_CONTENTS:?}"
+: "${CF_ADMIN_PASSWORD:?}"
+: "${CF_API_URL:?}"
+: "${GOPATH:?}"
+: "${CF_DEPLOYMENT_NAME:="cf"}"
+: "${CF_ADMIN_USERNAME:="admin"}"
+: "${BOSH_ENVIRONMENT:?}"
+
+tmpdir="$( mktemp -d /tmp/run-drats.XXXXXXXXXX )"
+
+ssh_key="${tmpdir}/bosh.pem"
+echo "${BOSH_GW_PRIVATE_KEY_CONTENTS}" > "${ssh_key}"
+chmod 600 "${ssh_key}"
+echo "Starting SSH tunnel, you may be prompted for your OS password..."
+sudo true # prompt for password
+sshuttle -e "ssh -i "${ssh_key}" -o 'StrictHostKeyChecking no' -o 'UserKnownHostsFile /dev/null'" -r "${BOSH_GW_USER}@${BOSH_GW_HOST}" 10.0.0.0/8 &
+tunnel_pid="$!"
+
+cleanup() {
+  kill "${tunnel_pid}"
+  rm -rf "${tmpdir}"
+}
+trap 'cleanup' EXIT
+
+if [ -n "${BOSH_CA_CERT}" ]; then
+  export BOSH_CERT_PATH="${tmpdir}/bosh.ca"
+  echo "${BOSH_CA_CERT}" > "${BOSH_CERT_PATH}"
+fi
+
+export BBR_BUILD_PATH=$(which bbr)
+export BOSH_URL="${BOSH_ENVIRONMENT}"
+
+echo "Running DRATs..."
+. ./scripts/run_acceptance_tests.sh
+
+echo "Successfully ran DRATs!"

--- a/scripts/run_acceptance_tests.sh
+++ b/scripts/run_acceptance_tests.sh
@@ -12,6 +12,6 @@ export BOSH_CLIENT_SECRET
 export BOSH_URL
 export BBR_BUILD_PATH
 
-go get github.com/onsi/ginkgo/ginkgo
-glide install --strip-vendor
+#go get github.com/onsi/ginkgo/ginkgo
+#glide install --strip-vendor
 ginkgo -v -r --trace .

--- a/scripts/run_acceptance_tests.sh
+++ b/scripts/run_acceptance_tests.sh
@@ -12,6 +12,6 @@ export BOSH_CLIENT_SECRET
 export BOSH_URL
 export BBR_BUILD_PATH
 
-#go get github.com/onsi/ginkgo/ginkgo
-#glide install --strip-vendor
+go get github.com/onsi/ginkgo/ginkgo
+glide install --strip-vendor
 ginkgo -v -r --trace .


### PR DESCRIPTION
Also add the run-drats.sh script, to run the drats locally. This
required us to comment out some lines in run_acceptance_tests.sh.

[#151561511](https://www.pivotaltracker.com/story/show/151561511)

Thanks,
Tim and @matt-royal 

## Checklist

Please provide the following information:

* **What component are you testing?:** Cloud Controller
* **Have you created a TestCase and added it to the list of cases to be run?:** No, updated an existing test
* **Have you manually validated your TestCase against a deployed Cloud Foundry? If so, which version?:**  We tested against the latest cf-deployment with capi-release `1.43.0`
* **Does this change rely on a particular version of CF release?:**  No, it just adds an additional assertion that should have already been passing
* **Are you available for a cross-team pair to help troubleshoot your PR?:**  Sure, time-zone permitting :)

### Do you have any other useful information for us?

We'll leave comments on the specific lines of code.

We're on the #pcf-backup-restore Slack channel if you need us.