### PR TITLE
local script: use existing value for BBR_BUILD_PATH if it is set

### DIFF
--- a/scripts/run_acceptance_tests_local.sh
+++ b/scripts/run_acceptance_tests_local.sh
@@ -46,7 +46,7 @@ if [ -n "${BOSH_CA_CERT}" ]; then
   echo "${BOSH_CA_CERT}" > "${BOSH_CERT_PATH}"
 fi
 
-export BBR_BUILD_PATH=$(which bbr)
+export BBR_BUILD_PATH="${BBR_BUILD_PATH:-$(which bbr)}"
 export BOSH_URL="${BOSH_ENVIRONMENT}"
 
 echo "Running DRATs..."


### PR DESCRIPTION
makes it possible to use `./scripts/run_acceptance_tests_local.sh` from a CI job that has the `bbr` binary somewhere not on the `$PATH` (e.g. in a concourse resource).