### PR TITLE
Include NFS broker tests if the password is set

### DIFF
--- a/ci/credhub-compatible/update-integration-config/task.sh
+++ b/ci/credhub-compatible/update-integration-config/task.sh
@@ -59,8 +59,8 @@ do
   integration_config=$(echo "${integration_config}" | jq ".${config}=\"${!config}\"")
 done
 
-if [[ -z ${nfs_broker_password} ]]; then
-  integration_config=$(echo "${integration_config}" | jq '."include_cf-nfsbroker"=false')
+if [[ -n ${nfs_broker_password} ]]; then
+  integration_config=$(echo "${integration_config}" | jq '."include_cf-nfsbroker"=true')
 fi
 
 echo "${integration_config}" > "integration-configs/${INTEGRATION_CONFIG_FILE_PATH}"


### PR DESCRIPTION
Hi,

This PR updated the `credhub-compatible/update-integration-config` CI task to include the CF NFS broker test suite if the NFS broker password is set, instead of excluding it if the password is not set. This change is necessary since the default value for the `include_cf-nfsbroker` config flag was changed from true to false here: https://github.com/cloudfoundry-incubator/disaster-recovery-acceptance-tests/commit/0e307e47e809ba13747c3885efdaef0c3fe62077

[#159975576](https://www.pivotaltracker.com/story/show/159975576)

Please let me know if you have any questions.

Dave