### PR TITLE
Add perm testcase as experimental drat

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -4,8 +4,11 @@
 [[projects]]
   branch = "master"
   name = "code.cloudfoundry.org/routing-api"
-  packages = [".","models"]
-  revision = "19a313d357db153fe852114558e66030de95d945"
+  packages = [
+    ".",
+    "models"
+  ]
+  revision = "b308b1a648d23d5bf691565fffc14524bda52680"
 
 [[projects]]
   branch = "master"
@@ -20,16 +23,16 @@
   revision = "6226ea591a40176dd3ff9cd8eff81ed6ca721a00"
 
 [[projects]]
-  name = "github.com/gorilla/context"
-  packages = ["."]
-  revision = "1ea25387ff6f684839d82767c1733ff4d4d15d0a"
-  version = "v1.1"
-
-[[projects]]
-  name = "github.com/gorilla/mux"
-  packages = ["."]
-  revision = "7f08801859139f86dfafd1c296e2cba9a80d292e"
-  version = "v1.6.0"
+  name = "github.com/hpcloud/tail"
+  packages = [
+    ".",
+    "ratelimiter",
+    "util",
+    "watch",
+    "winfile"
+  ]
+  revision = "a30252cb686a21eb2d0b98132633053ec2f7f1e5"
+  version = "v1.0.0"
 
 [[projects]]
   branch = "master"
@@ -39,20 +42,49 @@
 
 [[projects]]
   name = "github.com/onsi/ginkgo"
-  packages = [".","config","internal/codelocation","internal/containernode","internal/failer","internal/leafnodes","internal/remote","internal/spec","internal/spec_iterator","internal/specrunner","internal/suite","internal/testingtproxy","internal/writer","reporters","reporters/stenographer","reporters/stenographer/support/go-colorable","reporters/stenographer/support/go-isatty","types"]
-  revision = "8382b23d18dbaaff8e5f7e83784c53ebb8ec2f47"
+  packages = [
+    ".",
+    "config",
+    "internal/codelocation",
+    "internal/containernode",
+    "internal/failer",
+    "internal/leafnodes",
+    "internal/remote",
+    "internal/spec",
+    "internal/spec_iterator",
+    "internal/specrunner",
+    "internal/suite",
+    "internal/testingtproxy",
+    "internal/writer",
+    "reporters",
+    "reporters/stenographer",
+    "reporters/stenographer/support/go-colorable",
+    "reporters/stenographer/support/go-isatty",
+    "types"
+  ]
+  revision = "3774a09d95489ccaa16032e0770d08ea77ba6184"
+  version = "v1.6.0"
 
 [[projects]]
   name = "github.com/onsi/gomega"
-  packages = [".","format","gbytes","gexec","internal/assertion","internal/asyncassertion","internal/oraclematcher","internal/testingtsupport","matchers","matchers/support/goraph/bipartitegraph","matchers/support/goraph/edge","matchers/support/goraph/node","matchers/support/goraph/util","types"]
-  revision = "c893efa28eb45626cdaa76c9f653b62488858837"
-  version = "v1.2.0"
-
-[[projects]]
-  name = "github.com/satori/go.uuid"
-  packages = ["."]
-  revision = "879c5887cd475cd7864858769793b2ceb0d44feb"
-  version = "v1.1.0"
+  packages = [
+    ".",
+    "format",
+    "gbytes",
+    "gexec",
+    "internal/assertion",
+    "internal/asyncassertion",
+    "internal/oraclematcher",
+    "internal/testingtsupport",
+    "matchers",
+    "matchers/support/goraph/bipartitegraph",
+    "matchers/support/goraph/edge",
+    "matchers/support/goraph/node",
+    "matchers/support/goraph/util",
+    "types"
+  ]
+  revision = "b6ea1ea48f981d0f615a154a45eabb9dd466556d"
+  version = "v1.4.1"
 
 [[projects]]
   name = "github.com/tedsuo/rata"
@@ -67,28 +99,67 @@
   revision = "fd69d275caac5d78d793e77ddbe9bd2001d9b88d"
 
 [[projects]]
+  branch = "master"
   name = "golang.org/x/net"
-  packages = ["html","html/atom","html/charset"]
-  revision = "cd95c68ba21fc7ee16ee38cc420473e3d8c4afd8"
+  packages = [
+    "html",
+    "html/atom",
+    "html/charset"
+  ]
+  revision = "8a410e7b638dca158bf9e766925842f6651ff828"
 
 [[projects]]
+  branch = "master"
   name = "golang.org/x/sys"
   packages = ["unix"]
-  revision = "b0e0dd72976dc482b6cb37c5640440f876ac1907"
+  revision = "ebe1bf3edb3325c393447059974de898d5133eb8"
 
 [[projects]]
   name = "golang.org/x/text"
-  packages = ["encoding","encoding/charmap","encoding/htmlindex","encoding/internal","encoding/internal/identifier","encoding/japanese","encoding/korean","encoding/simplifiedchinese","encoding/traditionalchinese","encoding/unicode","internal/gen","internal/tag","internal/utf8internal","language","runes","transform","unicode/cldr"]
-  revision = "3bd178b88a8180be2df394a1fbb81313916f0e7b"
+  packages = [
+    "encoding",
+    "encoding/charmap",
+    "encoding/htmlindex",
+    "encoding/internal",
+    "encoding/internal/identifier",
+    "encoding/japanese",
+    "encoding/korean",
+    "encoding/simplifiedchinese",
+    "encoding/traditionalchinese",
+    "encoding/unicode",
+    "internal/gen",
+    "internal/tag",
+    "internal/utf8internal",
+    "language",
+    "runes",
+    "transform",
+    "unicode/cldr"
+  ]
+  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
+  version = "v0.3.0"
+
+[[projects]]
+  name = "gopkg.in/fsnotify.v1"
+  packages = ["."]
+  revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
+  source = "https://github.com/fsnotify/fsnotify"
+  version = "v1.4.7"
+
+[[projects]]
+  branch = "v1"
+  name = "gopkg.in/tomb.v1"
+  packages = ["."]
+  revision = "dd632973f1e7218eb1089048e0798ec9ae7dceb8"
 
 [[projects]]
   name = "gopkg.in/yaml.v2"
   packages = ["."]
-  revision = "25c4ec802a7d637f88d584ab26798e94ad14c13b"
+  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
+  version = "v2.2.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c83945556c539f6ea1d1cf6792ff79b3f689fa405b9d9251ab5c1f406c79d4b4"
+  inputs-digest = "e11a10fb2876311458381069e66d7a6bbdc53246aea4ca5593bbcbeac7d6615e"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,6 +3,15 @@
 
 [[projects]]
   branch = "master"
+  name = "code.cloudfoundry.org/perm"
+  packages = [
+    "pkg/api/protos",
+    "pkg/perm"
+  ]
+  revision = "f2579a178f77944d1fde9b627219006855cdb97f"
+
+[[projects]]
+  branch = "master"
   name = "code.cloudfoundry.org/routing-api"
   packages = [
     ".",
@@ -21,6 +30,28 @@
   name = "github.com/bmizerany/pat"
   packages = ["."]
   revision = "6226ea591a40176dd3ff9cd8eff81ed6ca721a00"
+
+[[projects]]
+  name = "github.com/gogo/protobuf"
+  packages = [
+    "gogoproto",
+    "proto",
+    "protoc-gen-gogo/descriptor"
+  ]
+  revision = "636bf0302bc95575d69441b25a2603156ffdddf1"
+  version = "v1.1.1"
+
+[[projects]]
+  name = "github.com/golang/protobuf"
+  packages = [
+    "proto",
+    "ptypes",
+    "ptypes/any",
+    "ptypes/duration",
+    "ptypes/timestamp"
+  ]
+  revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
+  version = "v1.2.0"
 
 [[projects]]
   name = "github.com/hpcloud/tail"
@@ -102,11 +133,28 @@
   branch = "master"
   name = "golang.org/x/net"
   packages = [
+    "context",
+    "context/ctxhttp",
     "html",
     "html/atom",
-    "html/charset"
+    "html/charset",
+    "http/httpguts",
+    "http2",
+    "http2/hpack",
+    "idna",
+    "internal/timeseries",
+    "trace"
   ]
   revision = "8a410e7b638dca158bf9e766925842f6651ff828"
+
+[[projects]]
+  branch = "master"
+  name = "golang.org/x/oauth2"
+  packages = [
+    ".",
+    "internal"
+  ]
+  revision = "d2e6202438beef2727060aa7cabdd924d92ebfd9"
 
 [[projects]]
   branch = "master"
@@ -117,6 +165,8 @@
 [[projects]]
   name = "golang.org/x/text"
   packages = [
+    "collate",
+    "collate/build",
     "encoding",
     "encoding/charmap",
     "encoding/htmlindex",
@@ -127,16 +177,76 @@
     "encoding/simplifiedchinese",
     "encoding/traditionalchinese",
     "encoding/unicode",
+    "internal/colltab",
     "internal/gen",
     "internal/tag",
+    "internal/triegen",
+    "internal/ucd",
     "internal/utf8internal",
     "language",
     "runes",
+    "secure/bidirule",
     "transform",
-    "unicode/cldr"
+    "unicode/bidi",
+    "unicode/cldr",
+    "unicode/norm",
+    "unicode/rangetable"
   ]
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
+
+[[projects]]
+  name = "google.golang.org/appengine"
+  packages = [
+    "internal",
+    "internal/base",
+    "internal/datastore",
+    "internal/log",
+    "internal/remote_api",
+    "internal/urlfetch",
+    "urlfetch"
+  ]
+  revision = "b1f26356af11148e710935ed1ac8a7f5702c7612"
+  version = "v1.1.0"
+
+[[projects]]
+  branch = "master"
+  name = "google.golang.org/genproto"
+  packages = ["googleapis/rpc/status"]
+  revision = "11092d34479b07829b72e10713b159248caf5dad"
+
+[[projects]]
+  name = "google.golang.org/grpc"
+  packages = [
+    ".",
+    "balancer",
+    "balancer/base",
+    "balancer/roundrobin",
+    "codes",
+    "connectivity",
+    "credentials",
+    "encoding",
+    "encoding/proto",
+    "grpclog",
+    "internal",
+    "internal/backoff",
+    "internal/channelz",
+    "internal/envconfig",
+    "internal/grpcrand",
+    "internal/transport",
+    "keepalive",
+    "metadata",
+    "naming",
+    "peer",
+    "resolver",
+    "resolver/dns",
+    "resolver/passthrough",
+    "stats",
+    "status",
+    "tap"
+  ]
+  revision = "32fb0ac620c32ba40a4626ddf94d90d12cce3455"
+  version = "v1.14.0"
 
 [[projects]]
   name = "gopkg.in/fsnotify.v1"
@@ -160,6 +270,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e11a10fb2876311458381069e66d7a6bbdc53246aea4ca5593bbcbeac7d6615e"
+  inputs-digest = "ecae6d3df61d013a61c3e7415f2a9e25ba201a7ab398728dfb3fae1386f9dbd9"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -4,3 +4,7 @@
 
 [[constraint]]
   name = "github.com/onsi/gomega"
+
+[[override]]
+  name = "gopkg.in/fsnotify.v1"
+  source = "https://github.com/fsnotify/fsnotify"

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Tests if Cloud Foundry can be backed up and restored. The tests will back up fro
     * `NFS_BROKER_PASSWORD` - Environment variable required to run NFS test case
     * `NFS_BROKER_URL` - Environment variable required to run NFS test case
     * `DELETE_AND_REDEPLOY_CF` - set to "true" to have the CF deployment destroyed and redeployed from scratch during the test cycle. **<span style="color:red"> Exercise extreme care when using this option!</span>**
+    * `RUN_EXPERIMENTAL_TEST_CASES` - set to "true" to also run the experimental test cases, such as Perm
+    * `PERM_CA` - set to the Perm server's TLS certificate authority if running the experimental test cases
+    * `PERM_URL` - set to the Perm server's URL if running the experimental test cases
 1. If you wish to run DRATS against a director deployed with `bbl`, run `scripts/run_acceptance_tests_with_bbl_env.sh <path-to-bbl-state-dir>`.
     * Set `CF_VARS_STORE_PATH` to the path to the CF vars-store file.
     * Set `BOSH_CLI_NAME` to the name of the BOSH CLI executable on your machine if it isn't `bosh`.
@@ -100,6 +103,7 @@ If these variables are not set, all test suites returned by [`testcases.OpenSour
 * `bosh_client_secret` - BOSH Director password
 * `bosh_ca_cert` - BOSH Director's CA cert content
 * `include_<testcase-name>` - Flag for whether to run a given testcase. If omitted defaults to false
+* `run_experimental_test_cases` - Flag to include experimental test cases. If omitted defaults to false
 
 #### Optional Variables
 * `nfs_service_name` - Environment variable required to run NFS test case
@@ -109,6 +113,8 @@ If these variables are not set, all test suites returned by [`testcases.OpenSour
 * `nfs_broker_url` - Environment variable required to run NFS test case
 * `timeout_in_minutes` - Default ginkgo `Eventually` timeout. Defaults to 15
 * `delete_and_redeploy_cf` - Destroy and redeploy the cf between after backup and restore. Defaults to false.
+* `perm_ca` - Perm server's TLS certificate authority. Required only if running experimental test cases.
+* `perm_url` - Perm server's URL. Necessary only if running experimental test cases.
 
 ## Test Structure
 

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -19,5 +19,11 @@ var _ = Describe("backing up Cloud Foundry", func() {
 		conf, filter = config.FromEnv()
 	}
 
-	runner.RunDisasterRecoveryAcceptanceTests(conf, filter.Filter(testcases.OpenSourceTestCases()))
+	testCases := testcases.OpenSourceTestCases()
+
+	if conf.RunExperimentalTestCases {
+		testCases = append(testCases, testcases.ExperimentalTestCases()...)
+	}
+
+	runner.RunDisasterRecoveryAcceptanceTests(conf, filter.Filter(testCases))
 })

--- a/config/env.go
+++ b/config/env.go
@@ -28,6 +28,12 @@ func FromEnv() (runner.Config, runner.TestCaseFilter) {
 	deploymentConfig.NFSBrokerUser = os.Getenv("NFS_BROKER_USER")
 	deploymentConfig.NFSBrokerPassword = os.Getenv("NFS_BROKER_PASSWORD")
 	deploymentConfig.NFSBrokerUrl = os.Getenv("NFS_BROKER_URL")
+	deploymentConfig.RunExperimentalTestCases = os.Getenv("RUN_EXPERIMENTAL_TEST_CASES") == "true"
+
+	if deploymentConfig.RunExperimentalTestCases {
+		deploymentConfig.PermCA = mustHaveEnv("PERM_CA")
+		deploymentConfig.PermUrl = mustHaveEnv("PERM_URL")
+	}
 
 	timeout := TimeoutFromEnv()
 

--- a/runner/config.go
+++ b/runner/config.go
@@ -12,6 +12,9 @@ type CloudFoundryConfig struct {
 	NFSBrokerUser                     string `json:"nfs_broker_user,omitempty"`
 	NFSBrokerPassword                 string `json:"nfs_broker_password,omitempty"`
 	NFSBrokerUrl                      string `json:"nfs_broker_url,omitempty"`
+	PermCA                            string `json:"perm_ca,omitempty"`
+	PermUrl                           string `json:"perm_url,omitempty"`
+	RunExperimentalTestCases          bool   `json:"run_experimental_test_cases,omitempty"`
 	NotificationsTemplateClientID     string
 	NotificationsTemplateClientSecret string
 }

--- a/scripts/_run_acceptance_tests.sh
+++ b/scripts/_run_acceptance_tests.sh
@@ -19,6 +19,9 @@ export BBR_BUILD_PATH
 export FOCUSED_SUITE_NAME
 export SKIP_SUITE_NAME
 export DELETE_AND_REDEPLOY_CF
+export RUN_EXPERIMENTAL_TEST_CASES
+export PERM_CA
+export PERM_URL
 
 go get github.com/onsi/ginkgo/ginkgo
 dep ensure

--- a/scripts/run_acceptance_tests_local.sh
+++ b/scripts/run_acceptance_tests_local.sh
@@ -23,6 +23,8 @@ set -eu -o pipefail
 : "${NFS_BROKER_PASSWORD:=""}"
 : "${NFS_BROKER_URL:=""}"
 : "${SKIP_SUITE_NAME:=""}"
+: "${PERM_CA:=""}"
+: "${PERM_URL:=""}"
 
 tmpdir="$( mktemp -d /tmp/run-drats.XXXXXXXXXX )"
 

--- a/testcases/perm_testcase.go
+++ b/testcases/perm_testcase.go
@@ -1,0 +1,108 @@
+package testcases
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+
+	"code.cloudfoundry.org/perm/pkg/perm"
+
+	. "github.com/cloudfoundry-incubator/disaster-recovery-acceptance-tests/runner"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+type PermTestCase struct {
+	uniqueTestID string
+	roleName     string
+	actor        perm.Actor
+	permission   perm.Permission
+	name         string
+}
+
+func NewPermTestCase() *PermTestCase {
+	id := RandomStringNumber()
+	actor := perm.Actor{
+		ID:        id,
+		Namespace: "actor_" + id,
+	}
+	permission := perm.Permission{
+		Action:          "permission_" + id,
+		ResourcePattern: "resource_" + id,
+	}
+	return &PermTestCase{
+		uniqueTestID: id,
+		roleName:     "test_role_" + id,
+		actor:        actor,
+		permission:   permission,
+		name:         "perm",
+	}
+}
+
+func (tc *PermTestCase) Name() string {
+	return tc.name
+}
+
+func (tc *PermTestCase) BeforeBackup(config Config) {
+	client := tc.permDial(config)
+	defer client.Close()
+
+	_, err := client.CreateRole(context.Background(), tc.roleName, tc.permission)
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Creating an actor with a given role")
+	err = client.AssignRole(context.Background(), tc.roleName, tc.actor)
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Verifying that the actor has the given permission")
+	ok, err := client.HasPermission(context.Background(), tc.actor, tc.permission.Action, tc.permission.ResourcePattern)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(ok).To(BeTrue())
+}
+
+func (tc *PermTestCase) AfterBackup(config Config) {
+	client := tc.permDial(config)
+	defer client.Close()
+
+	By("Deleting the actor")
+	err := client.DeleteRole(context.Background(), tc.roleName)
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Checking that the permission no longer exists")
+	ok, err := client.HasPermission(context.Background(), tc.actor, tc.permission.Action, tc.permission.ResourcePattern)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(ok).To(BeFalse())
+}
+
+func (tc *PermTestCase) AfterRestore(config Config) {
+	client := tc.permDial(config)
+	defer client.Close()
+
+	By("Checking that the actor and its permission have been restored")
+	ok, err := client.HasPermission(context.Background(), tc.actor, tc.permission.Action, tc.permission.ResourcePattern)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(ok).To(BeTrue())
+}
+
+func (tc *PermTestCase) Cleanup(config Config) {
+	client := tc.permDial(config)
+	defer client.Close()
+
+	err := client.DeleteRole(context.Background(), tc.roleName)
+	Expect(err).NotTo(HaveOccurred())
+}
+
+func (tc *PermTestCase) permDial(config Config) *perm.Client {
+	rootCAPool := x509.NewCertPool()
+
+	ok := rootCAPool.AppendCertsFromPEM([]byte(config.PermCA))
+	Expect(ok).To(BeTrue())
+
+	client, err := perm.Dial(
+		config.PermUrl,
+		perm.WithTLSConfig(&tls.Config{RootCAs: rootCAPool}),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	return client
+}

--- a/testcases/testcase_helper.go
+++ b/testcases/testcase_helper.go
@@ -15,3 +15,9 @@ func OpenSourceTestCases() []runner.TestCase {
 		NewCfCredhubSSITestCase(),
 	}
 }
+
+func ExperimentalTestCases() []runner.TestCase {
+	return []runner.TestCase{
+		NewPermTestCase(),
+	}
+}


### PR DESCRIPTION
Thanks for submitting a PR to DRATS.


## Checklist

Please provide the following information:

- [x] What component are you testing?
Perm
- [x] Have you created a `TestCase` and added it to the list of cases to be run?
Yes. However, we added it to a new test case group for experimental test cases, since most deployments don't yet include Perm.
- [ ] Have you added an `include_<testcase-name>` property and any other new properties to the sample integration_config.json?
No, since it's intended as an experimental testcase in a new group. 
- [x] Have you manually validated your `TestCase` against a deployed Cloud Foundry? If so, which version?
Yes, cf-deployment v4.1.0.
- [ ] Does this change rely on a particular version of CF release?
By default, no. The new (opt-in) test case does require Perm to be added to the deployment.
- [x] Are you available for a cross-team pair to help troubleshoot your PR?
Yes! We're on slack.
- [x] Have you submitted a pull request to modify the cf-deployment [backup and restore opsfile](https://github.com/cloudfoundry/cf-deployment/blob/master/operations/experimental/enable-backup-restore.yml) to add a backup job and properties where appropriate?
We currently have an ops file [here](https://github.com/cloudfoundry/cf-deployment/commit/b793f7de40dff3b8738df8fd4f9115e5c0d3e607). We'll be submitting a PR soon.

### Do you have any other useful information for us?

We're on the #bbr cloudfoundry Slack channel if you need us.
