### PR TITLE
Make Credhub tests backwards compatible with Credhub 1.7

### DIFF
--- a/testcases/credhub_instance_creds_testcase.go
+++ b/testcases/credhub_instance_creds_testcase.go
@@ -2,13 +2,14 @@ package testcases
 
 import (
 	"encoding/json"
-	"net/http"
-	"path"
-	. "github.com/cloudfoundry-incubator/disaster-recovery-acceptance-tests/runner"
-	. "github.com/onsi/gomega"
 	"fmt"
 	"io/ioutil"
+	"net/http"
+	"path"
 	"strings"
+
+	. "github.com/cloudfoundry-incubator/disaster-recovery-acceptance-tests/runner"
+	. "github.com/onsi/gomega"
 )
 
 type CfCredhubSSITestCase struct {
@@ -28,7 +29,7 @@ func NewCfCredhubSSITestCase() *CfCredhubSSITestCase {
 }
 
 var listResponse struct {
-	Credentials []struct{
+	Credentials []struct {
 		Name string
 	}
 }
@@ -44,11 +45,12 @@ func (tc *CfCredhubSSITestCase) BeforeBackup(config Config) {
 	RunCommandSuccessfully("cf create-space acceptance-test-space-" + tc.uniqueTestID + " -o acceptance-test-org-" + tc.uniqueTestID)
 	RunCommandSuccessfully("cf target -s acceptance-test-space-" + tc.uniqueTestID + " -o acceptance-test-org-" + tc.uniqueTestID)
 
-
 	var testAppPath = path.Join(CurrentTestDir(), "/../fixtures/credhub-test-app")
 	RunCommandSuccessfully("cf push " + "--no-start " + tc.appName + " -p " + testAppPath + " -b go_buildpack" + " -f " + testAppPath + "/manifest.yml")
-	RunCommandSuccessfully("cf set-env " + tc.appName + " CREDHUB_CLIENT "+ config.CloudFoundryConfig.CredHubClient + " > /dev/null")
-	RunCommandSuccessfully("cf set-env " + tc.appName + " CREDHUB_SECRET "+ config.CloudFoundryConfig.CredHubSecret + " > /dev/null")
+	if config.CloudFoundryConfig.CredHubClient != "" {
+		RunCommandSuccessfully("cf set-env " + tc.appName + " CREDHUB_CLIENT " + config.CloudFoundryConfig.CredHubClient + " > /dev/null")
+		RunCommandSuccessfully("cf set-env " + tc.appName + " CREDHUB_SECRET " + config.CloudFoundryConfig.CredHubSecret + " > /dev/null")
+	}
 	RunCommandSuccessfully("cf restart " + tc.appName)
 
 	tc.appURL = GetAppUrl(tc.appName)


### PR DESCRIPTION
## Checklist

Please provide the following information:

- [x] What component are you testing? **Credhub**
- [ ] Have you created a `TestCase` and added it to the list of cases to be run?
- [ ] Have you added an `include_<testcase-name>` property and any other new properties to the sample integration_config.json?
- [ ] Have you manually validated your `TestCase` against a deployed Cloud Foundry? If so, which version?
- [ ] Does this change rely on a particular version of CF release?
- [X] Are you available for a cross-team pair to help troubleshoot your PR?
- [ ] Have you submitted a pull request to modify the cf-deployment [backup and restore opsfile](https://github.com/cloudfoundry/cf-deployment/blob/master/operations/experimental/enable-backup-restore.yml) to add a backup job and properties where appropriate?

### Do you have any other useful information for us?

The tests in `credhub_instance_creds_testcase` are not backwards compatible with old versions that only used admin username and password. We had paired with @alamages on this who has the context on this fix. 

Please let us know if you need more information.

-- @heycait & @rizwanreza
