### PR TITLE
Use Ubuntu Bionic as base image for DRATs

### DIFF
--- a/ci/drats/task.yml
+++ b/ci/drats/task.yml
@@ -3,7 +3,7 @@ platform: linux
 
 image_resource:
   type: docker-image
-  source: {repository: cloudfoundrylondon/backup-and-restore-minimal}
+  source: {repository: cloudfoundrylondon/backup-and-restore-minimal:bionic}
 
 inputs:
 - name: disaster-recovery-acceptance-tests


### PR DESCRIPTION
PR intended to simply test the DRATs pipeline with a base Ubuntu Bionic Docker image

Story here: https://www.pivotaltracker.com/story/show/162195057

cc: @MModhaPivotal 
