### PR TITLE
Change CheckDeployment hooks for NFS and SMB test cases

### DIFF
--- a/ci/drats-with-integration-config/task.sh
+++ b/ci/drats-with-integration-config/task.sh
@@ -23,6 +23,11 @@ sshuttle -r "${BOSH_GW_USER}@${BOSH_GW_HOST}" "${SSH_DESTINATION_CIDR}" --daemon
 
 sleep 5
 
+if ! stat sshuttle.pid > /dev/null 2>&1; then
+  echo "Failed to start sshuttle daemon"
+  exit 1
+fi
+
 pushd bbr-binary-release
   tar xvf ./*.tar
   export BBR_BUILD_PATH="$PWD/releases/bbr"

--- a/ci/drats/task.sh
+++ b/ci/drats/task.sh
@@ -16,6 +16,11 @@ sshuttle -r "${BOSH_GW_USER}@${BOSH_GW_HOST}" "${SSH_DESTINATION_CIDR}" --daemon
 
 sleep 5
 
+if ! stat sshuttle.pid > /dev/null 2>&1; then
+  echo "Failed to start sshuttle daemon"
+  exit 1
+fi
+
 echo "$BOSH_CA_CERT" > bosh.cert
 export BOSH_CERT_PATH="$PWD/bosh.cert"
 

--- a/config/env.go
+++ b/config/env.go
@@ -18,7 +18,7 @@ func FromEnv() (runner.Config, runner.TestCaseFilter) {
 	}
 	deploymentConfig := runner.CloudFoundryConfig{
 		Name:          mustHaveEnv("CF_DEPLOYMENT_NAME"),
-		ApiUrl:        mustHaveEnv("CF_API_URL"),
+		APIURL:        mustHaveEnv("CF_API_URL"),
 		AdminUsername: mustHaveEnv("CF_ADMIN_USERNAME"),
 		AdminPassword: mustHaveEnv("CF_ADMIN_PASSWORD"),
 	}
@@ -27,13 +27,13 @@ func FromEnv() (runner.Config, runner.TestCaseFilter) {
 	deploymentConfig.NFSPlanName = os.Getenv("NFS_PLAN_NAME")
 	deploymentConfig.NFSBrokerUser = os.Getenv("NFS_BROKER_USER")
 	deploymentConfig.NFSBrokerPassword = os.Getenv("NFS_BROKER_PASSWORD")
-	deploymentConfig.NFSBrokerUrl = os.Getenv("NFS_BROKER_URL")
+	deploymentConfig.NFSBrokerURL = os.Getenv("NFS_BROKER_URL")
 
 	deploymentConfig.SMBServiceName = os.Getenv("SMB_SERVICE_NAME")
 	deploymentConfig.SMBPlanName = os.Getenv("SMB_PLAN_NAME")
 	deploymentConfig.SMBBrokerUser = os.Getenv("SMB_BROKER_USER")
 	deploymentConfig.SMBBrokerPassword = os.Getenv("SMB_BROKER_PASSWORD")
-	deploymentConfig.SMBBrokerUrl = os.Getenv("SMB_BROKER_URL")
+	deploymentConfig.SMBBrokerURL = os.Getenv("SMB_BROKER_URL")
 	deploymentConfig.CredHubClient = os.Getenv("CF_CREDHUB_CLIENT")
 	deploymentConfig.CredHubSecret = os.Getenv("CF_CREDHUB_SECRET")
 

--- a/runner/cf_helpers.go
+++ b/runner/cf_helpers.go
@@ -12,23 +12,24 @@ import (
 	"fmt"
 	"net/url"
 
+	"io"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"io"
 )
 
-func GetAppUrl(appName string) string {
+func GetAppURL(appName string) string {
 	appStats := string(RunCommandAndRetry("cf app "+appName, 5).Out.Contents())
-	var appUrl string
+	var appURL string
 	for _, line := range strings.Split(appStats, "\n") {
 		if strings.HasPrefix(line, "routes:") {
 			s := strings.Split(line, " ")
-			appUrl = s[len(s)-1]
+			appURL = s[len(s)-1]
 		}
 	}
 
-	Expect(appUrl).NotTo(BeEmpty())
-	return appUrl
+	Expect(appURL).NotTo(BeEmpty())
+	return appURL
 }
 
 func Get(url string) *http.Response {
@@ -44,16 +45,16 @@ func Post(url string, contentType string, body io.Reader) *http.Response {
 	client := &http.Client{Transport: &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}}
-	response, err := client.Post("https://" + url, contentType, body)
+	response, err := client.Post("https://"+url, contentType, body)
 	Expect(err).NotTo(HaveOccurred())
 	return response
 }
 
-func StatusCode(rawUrl string) func() (int, error) {
-	parsedUrl, err := url.Parse(rawUrl)
+func StatusCode(rawURL string) func() (int, error) {
+	parsedURL, err := url.Parse(rawURL)
 	Expect(err).NotTo(HaveOccurred(), "error parsing api url")
-	if parsedUrl.Scheme == "" {
-		parsedUrl.Scheme = "https"
+	if parsedURL.Scheme == "" {
+		parsedURL.Scheme = "https"
 	}
 
 	return func() (int, error) {
@@ -64,8 +65,8 @@ func StatusCode(rawUrl string) func() (int, error) {
 					InsecureSkipVerify: true,
 				},
 			}}
-		fmt.Fprintf(GinkgoWriter, "Trying to connect to api url: %s\n", parsedUrl.String())
-		resp, err := client.Get(parsedUrl.String())
+		fmt.Fprintf(GinkgoWriter, "Trying to connect to api url: %s\n", parsedURL.String())
+		resp, err := client.Get(parsedURL.String())
 		Expect(err).NotTo(HaveOccurred(), "error connecting to api url")
 		return resp.StatusCode, err
 	}

--- a/runner/config.go
+++ b/runner/config.go
@@ -4,7 +4,7 @@ import "time"
 
 type CloudFoundryConfig struct {
 	Name                              string `json:"cf_deployment_name"`
-	ApiUrl                            string `json:"cf_api_url"`
+	APIURL                            string `json:"cf_api_url"`
 	AdminUsername                     string `json:"cf_admin_username"`
 	AdminPassword                     string `json:"cf_admin_password"`
 	CredHubClient                     string `json:"credhub_client_name"`
@@ -14,13 +14,13 @@ type CloudFoundryConfig struct {
 	NFSCreateServiceBroker            bool   `json:"nfs_create_service_broker,omitempty"`
 	NFSBrokerUser                     string `json:"nfs_broker_user,omitempty"`
 	NFSBrokerPassword                 string `json:"nfs_broker_password,omitempty"`
-	NFSBrokerUrl                      string `json:"nfs_broker_url,omitempty"`
+	NFSBrokerURL                      string `json:"nfs_broker_url,omitempty"`
 	SMBServiceName                    string `json:"smb_service_name,omitempty"`
 	SMBPlanName                       string `json:"smb_plan_name,omitempty"`
 	SMBCreateServiceBroker            bool   `json:"smb_create_service_broker,omitempty"`
 	SMBBrokerUser                     string `json:"smb_broker_user,omitempty"`
 	SMBBrokerPassword                 string `json:"smb_broker_password,omitempty"`
-	SMBBrokerUrl                      string `json:"smb_broker_url,omitempty"`
+	SMBBrokerURL                      string `json:"smb_broker_url,omitempty"`
 	NotificationsTemplateClientID     string
 	NotificationsTemplateClientSecret string
 }

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -22,12 +22,12 @@ func RunDisasterRecoveryAcceptanceTests(config Config, testCases []TestCase) {
 	var err error
 
 	BeforeEach(func() {
-		fmt.Println("Running test cases:")
+		fmt.Println("\nRunning test cases:")
 		for _, testCase := range testCases {
 			fmt.Println(testCase.Name())
 		}
 
-		fmt.Println("Checking deployment has been set up for test cases...")
+		fmt.Println("\nChecking deployment has been set up for test cases...")
 		for _, testCase := range testCases {
 			testCase.CheckDeployment(config)
 		}

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -73,7 +73,7 @@ func RunDisasterRecoveryAcceptanceTests(config Config, testCases []TestCase) {
 			))
 		backupRunning = false
 
-		Eventually(StatusCode(config.CloudFoundryConfig.ApiUrl), 5*time.Minute).Should(Equal(200))
+		Eventually(StatusCode(config.CloudFoundryConfig.APIURL), 5*time.Minute).Should(Equal(200))
 
 		for _, testCase := range testCases {
 			By("running the AfterBackup step for " + testCase.Name())
@@ -134,7 +134,7 @@ func RunDisasterRecoveryAcceptanceTests(config Config, testCases []TestCase) {
 			))
 		restoreRunning = false
 
-		Eventually(StatusCode(config.CloudFoundryConfig.ApiUrl), 5*time.Minute).Should(Equal(200))
+		Eventually(StatusCode(config.CloudFoundryConfig.APIURL), 5*time.Minute).Should(Equal(200))
 
 		By("checking state in restored environment")
 		for _, testCase := range testCases {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -22,14 +22,14 @@ func RunDisasterRecoveryAcceptanceTests(config Config, testCases []TestCase) {
 	var err error
 
 	BeforeEach(func() {
-
-		for _, testCase := range testCases {
-			testCase.CheckDeployment(config)
-		}
-
-		fmt.Println("Running testcases:")
+		fmt.Println("Running test cases:")
 		for _, testCase := range testCases {
 			fmt.Println(testCase.Name())
+		}
+
+		fmt.Println("Checking deployment has been set up for test cases...")
+		for _, testCase := range testCases {
+			testCase.CheckDeployment(config)
 		}
 
 		backupRunning = false

--- a/scripts/run_acceptance_tests_local.sh
+++ b/scripts/run_acceptance_tests_local.sh
@@ -31,6 +31,12 @@ set -eu -o pipefail
 : "${SMB_BROKER_URL:=""}"
 : "${SKIP_SUITE_NAME:=""}"
 
+cleanup() {
+  rm -rf "${tmpdir}"
+  kill "$(cat sshuttle.pid)"
+}
+trap 'cleanup' EXIT
+
 tmpdir="$( mktemp -d /tmp/run-drats.XXXXXXXXXX )"
 
 ssh_key="${tmpdir}/bosh.pem"
@@ -39,13 +45,13 @@ chmod 600 "${ssh_key}"
 echo "Starting SSH tunnel, you may be prompted for your OS password..."
 sudo true # prompt for password
 sshuttle -e "ssh -i ${ssh_key} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" -r "${BOSH_GW_USER}@${BOSH_GW_HOST}" ${SSH_DESTINATION_CIDR} &
-tunnel_pid="$!"
 
-cleanup() {
-  kill "${tunnel_pid}"
-  rm -rf "${tmpdir}"
-}
-trap 'cleanup' EXIT
+sleep 5
+
+if ! stat sshuttle.pid > /dev/null 2>&1; then
+  echo "Failed to start sshuttle daemon"
+  exit 1
+fi
 
 if [ -n "${BOSH_CA_CERT}" ]; then
   export BOSH_CERT_PATH="${tmpdir}/bosh.ca"

--- a/scripts/run_acceptance_tests_local.sh
+++ b/scripts/run_acceptance_tests_local.sh
@@ -33,7 +33,12 @@ set -eu -o pipefail
 
 cleanup() {
   rm -rf "${tmpdir}"
-  kill "$(cat sshuttle.pid)"
+
+  echo "Closing SSH tunnel..."
+  if [[ -f sshuttle.pid ]]; then
+    kill "$(cat sshuttle.pid)"
+  fi
+  rm -f sshuttle.pid
 }
 trap 'cleanup' EXIT
 

--- a/scripts/run_acceptance_tests_local_with_config.sh
+++ b/scripts/run_acceptance_tests_local_with_config.sh
@@ -10,7 +10,12 @@ set -eu -o pipefail
 
 cleanup() {
   rm -rf "${tmpdir}"
-  kill "$(cat sshuttle.pid)"
+
+  echo "Closing SSH tunnel..."
+  if [[ -f sshuttle.pid ]]; then
+    kill "$(cat sshuttle.pid)"
+  fi
+  rm -f sshuttle.pid
 }
 trap 'cleanup' EXIT
 

--- a/scripts/run_acceptance_tests_local_with_config.sh
+++ b/scripts/run_acceptance_tests_local_with_config.sh
@@ -8,6 +8,12 @@ set -eu -o pipefail
 # The following params are optional
 : "${SKIP_SUITE_NAME:=""}"
 
+cleanup() {
+  rm -rf "${tmpdir}"
+  kill "$(cat sshuttle.pid)"
+}
+trap 'cleanup' EXIT
+
 tmpdir="$( mktemp -d /tmp/run-drats.XXXXXXXXXX )"
 
 BOSH_GW_USER=`jq -r .ssh_proxy_user ${CONFIG}`
@@ -21,13 +27,13 @@ chmod 600 "${ssh_key}"
 echo "Starting SSH tunnel, you may be prompted for your OS password..."
 sudo true # prompt for password
 sshuttle -e "ssh -i ${ssh_key} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" -r "${BOSH_GW_USER}@${BOSH_GW_HOST}" ${SSH_DESTINATION_CIDR} &
-tunnel_pid="$!"
 
-cleanup() {
-  kill "${tunnel_pid}"
-  rm -rf "${tmpdir}"
-}
-trap 'cleanup' EXIT
+sleep 5
+
+if ! stat sshuttle.pid > /dev/null 2>&1; then
+  echo "Failed to start sshuttle daemon"
+  exit 1
+fi
 
 export BBR_BUILD_PATH=$(which bbr)
 

--- a/testcases/cf_app_testcase.go
+++ b/testcases/cf_app_testcase.go
@@ -35,7 +35,7 @@ func (tc *CfAppTestCase) CheckDeployment(config Config) {
 
 func (tc *CfAppTestCase) BeforeBackup(config Config) {
 	By("creating new orgs and spaces")
-	RunCommandSuccessfully("cf api --skip-ssl-validation", config.CloudFoundryConfig.ApiUrl)
+	RunCommandSuccessfully("cf api --skip-ssl-validation", config.CloudFoundryConfig.APIURL)
 	RunCommandSuccessfully("cf auth", config.CloudFoundryConfig.AdminUsername, config.CloudFoundryConfig.AdminPassword)
 	RunCommandSuccessfully("cf create-org acceptance-test-org-" + tc.uniqueTestID)
 	RunCommandSuccessfully("cf create-space acceptance-test-space-" + tc.uniqueTestID + " -o acceptance-test-org-" + tc.uniqueTestID)
@@ -59,7 +59,7 @@ func (tc *CfAppTestCase) AfterRestore(config Config) {
 
 	By("verifying apps are back")
 	RunCommandSuccessfully("cf target -s acceptance-test-space-" + tc.uniqueTestID + " -o acceptance-test-org-" + tc.uniqueTestID)
-	url := GetAppUrl(tc.appName)
+	url := GetAppURL(tc.appName)
 
 	Eventually(StatusCode("https://"+url), 5*time.Minute, 5*time.Second).Should(Equal(200))
 	Expect(string(RunCommandSuccessfully("cf env " + tc.appName).Out.Contents())).To(MatchRegexp("winnebago" + tc.uniqueTestID))

--- a/testcases/cf_networking_testcase.go
+++ b/testcases/cf_networking_testcase.go
@@ -29,7 +29,7 @@ func (tc *CfNetworkingTestCase) CheckDeployment(config Config) {
 
 func (tc *CfNetworkingTestCase) BeforeBackup(config Config) {
 	By("creating new orgs and spaces")
-	RunCommandSuccessfully("cf api --skip-ssl-validation", config.CloudFoundryConfig.ApiUrl)
+	RunCommandSuccessfully("cf api --skip-ssl-validation", config.CloudFoundryConfig.APIURL)
 	RunCommandSuccessfully("cf auth", config.CloudFoundryConfig.AdminUsername, config.CloudFoundryConfig.AdminPassword)
 	RunCommandSuccessfully("cf create-org acceptance-test-org-" + tc.uniqueTestID)
 	RunCommandSuccessfully("cf create-space acceptance-test-space-" + tc.uniqueTestID + " -o acceptance-test-org-" + tc.uniqueTestID)

--- a/testcases/cf_uaa_testcase.go
+++ b/testcases/cf_uaa_testcase.go
@@ -20,7 +20,7 @@ func NewCfUaaTestCase() *CfUaaTestCase {
 }
 
 func login(config Config, username, password string) {
-	RunCommandSuccessfully("cf api --skip-ssl-validation", config.CloudFoundryConfig.ApiUrl)
+	RunCommandSuccessfully("cf api --skip-ssl-validation", config.CloudFoundryConfig.APIURL)
 	RunCommandSuccessfully("cf auth", username, password)
 }
 
@@ -44,7 +44,7 @@ func (tc *CfUaaTestCase) AfterBackup(config Config) {
 	login(config, config.CloudFoundryConfig.AdminUsername, config.CloudFoundryConfig.AdminPassword)
 	RunCommandSuccessfully("cf delete-user ", tc.testUser, "-f")
 	RunCommandSuccessfully("cf logout")
-	RunCommandSuccessfully("cf api --skip-ssl-validation", config.CloudFoundryConfig.ApiUrl)
+	RunCommandSuccessfully("cf api --skip-ssl-validation", config.CloudFoundryConfig.APIURL)
 
 	By("user has been deleted. authentication should fail")
 	result := RunCommand("cf auth", tc.testUser, tc.testPassword)

--- a/testcases/credhub_instance_creds_testcase.go
+++ b/testcases/credhub_instance_creds_testcase.go
@@ -42,7 +42,7 @@ func (tc *CfCredhubSSITestCase) CheckDeployment(config Config) {
 }
 
 func (tc *CfCredhubSSITestCase) BeforeBackup(config Config) {
-	RunCommandSuccessfully("cf api --skip-ssl-validation", config.CloudFoundryConfig.ApiUrl)
+	RunCommandSuccessfully("cf api --skip-ssl-validation", config.CloudFoundryConfig.APIURL)
 	RunCommandSuccessfully("cf auth", config.CloudFoundryConfig.AdminUsername, config.CloudFoundryConfig.AdminPassword)
 	RunCommandSuccessfully("cf create-org acceptance-test-org-" + tc.uniqueTestID)
 	RunCommandSuccessfully("cf create-space acceptance-test-space-" + tc.uniqueTestID + " -o acceptance-test-org-" + tc.uniqueTestID)
@@ -54,7 +54,7 @@ func (tc *CfCredhubSSITestCase) BeforeBackup(config Config) {
 	RunCommandSuccessfully("cf set-env " + tc.appName + " CREDHUB_SECRET " + config.CloudFoundryConfig.CredHubSecret + " > /dev/null")
 	RunCommandSuccessfully("cf restart " + tc.appName)
 
-	tc.appURL = GetAppUrl(tc.appName)
+	tc.appURL = GetAppURL(tc.appName)
 
 	appResponse := Get(tc.appURL + "/create")
 	body, _ := ioutil.ReadAll(appResponse.Body)

--- a/testcases/nfs_testcase.go
+++ b/testcases/nfs_testcase.go
@@ -24,11 +24,13 @@ func (tc *NFSTestCase) Name() string {
 }
 
 func (tc *NFSTestCase) CheckDeployment(config Config) {
-	By("checking if the nfsbroker app is present")
+	By("checking if the NFS service is registered")
 	RunCommandAndRetry("cf api --skip-ssl-validation", 3, config.CloudFoundryConfig.ApiUrl)
 	RunCommandAndRetry("cf auth", 3, config.CloudFoundryConfig.AdminUsername, config.CloudFoundryConfig.AdminPassword)
-	RunCommandSuccessfullyWithFailureMessage(tc.Name()+" test case cannot be run: space nfs-broker-space is not present", "cf target -o system -s nfs-broker-space")
-	RunCommandSuccessfullyWithFailureMessage(tc.Name()+" test case cannot be run: app nfs-broker is not present", "cf app nfs-broker")
+	RunCommandSuccessfullyWithFailureMessage(
+		tc.Name()+" test case cannot be run: NFS service is not registered",
+		"cf service-access -e "+config.CloudFoundryConfig.NFSServiceName,
+	)
 }
 
 func (tc *NFSTestCase) BeforeBackup(config Config) {

--- a/testcases/nfs_testcase.go
+++ b/testcases/nfs_testcase.go
@@ -25,7 +25,7 @@ func (tc *NFSTestCase) Name() string {
 
 func (tc *NFSTestCase) CheckDeployment(config Config) {
 	By("checking if the NFS service is registered")
-	RunCommandAndRetry("cf api --skip-ssl-validation", 3, config.CloudFoundryConfig.ApiUrl)
+	RunCommandAndRetry("cf api --skip-ssl-validation", 3, config.CloudFoundryConfig.APIURL)
 	RunCommandAndRetry("cf auth", 3, config.CloudFoundryConfig.AdminUsername, config.CloudFoundryConfig.AdminPassword)
 	RunCommandSuccessfullyWithFailureMessage(
 		tc.Name()+" test case cannot be run: NFS service is not registered",
@@ -39,8 +39,8 @@ func (tc *NFSTestCase) BeforeBackup(config Config) {
 	Expect(config.CloudFoundryConfig.NFSPlanName).NotTo(BeEmpty(), "required config NFS plan name not set")
 
 	By("creating an NFS service broker and service instance")
-	RunCommandSuccessfully("cf api --skip-ssl-validation", config.CloudFoundryConfig.ApiUrl)
-	RunCommandSuccessfully("cf login --skip-ssl-validation -a", config.CloudFoundryConfig.ApiUrl,
+	RunCommandSuccessfully("cf api --skip-ssl-validation", config.CloudFoundryConfig.APIURL)
+	RunCommandSuccessfully("cf login --skip-ssl-validation -a", config.CloudFoundryConfig.APIURL,
 		"-u", config.CloudFoundryConfig.AdminUsername, "-p", config.CloudFoundryConfig.AdminPassword)
 	orgName := "acceptance-test-org-" + tc.uniqueTestID
 	spaceName := "acceptance-test-space-" + tc.uniqueTestID
@@ -52,7 +52,7 @@ func (tc *NFSTestCase) BeforeBackup(config Config) {
 	if config.CloudFoundryConfig.NFSCreateServiceBroker {
 		RunCommandSuccessfully("cf create-service-broker nfsbroker-drats-" + tc.uniqueTestID + " " +
 			config.CloudFoundryConfig.NFSBrokerUser + " " + config.CloudFoundryConfig.NFSBrokerPassword + " " +
-			config.CloudFoundryConfig.NFSBrokerUrl)
+			config.CloudFoundryConfig.NFSBrokerURL)
 	}
 
 	RunCommandSuccessfully("cf enable-service-access " + config.CloudFoundryConfig.NFSServiceName + " -o " + orgName)

--- a/testcases/router_group_testcase.go
+++ b/testcases/router_group_testcase.go
@@ -59,7 +59,7 @@ func (tc *CfRouterGroupTestCase) BeforeBackup(config Config) {
 	By("Creating a pre-backup router group backup")
 	var err error
 
-	tc.routingAPIClient = routing_api.NewClient(config.CloudFoundryConfig.ApiUrl, true)
+	tc.routingAPIClient = routing_api.NewClient(config.CloudFoundryConfig.APIURL, true)
 	tc.routerGroupsPreBackup, err = tc.readRouterGroups(token)
 	Expect(err).NotTo(HaveOccurred())
 }
@@ -110,7 +110,7 @@ func (tc *CfRouterGroupTestCase) Cleanup(config Config) {
 }
 
 func loginAndGetToken(config Config) string {
-	RunCommandSuccessfully("cf login --skip-ssl-validation -a", config.CloudFoundryConfig.ApiUrl, "-u", config.CloudFoundryConfig.AdminUsername, "-p", config.CloudFoundryConfig.AdminPassword)
+	RunCommandSuccessfully("cf login --skip-ssl-validation -a", config.CloudFoundryConfig.APIURL, "-u", config.CloudFoundryConfig.AdminUsername, "-p", config.CloudFoundryConfig.AdminPassword)
 	return refreshToken()
 }
 

--- a/testcases/smb_testcase.go
+++ b/testcases/smb_testcase.go
@@ -24,11 +24,13 @@ func (tc *SMBTestCase) Name() string {
 }
 
 func (tc *SMBTestCase) CheckDeployment(config Config) {
-	By("checking if the smbbroker app is present")
+	By("checking if the SMB service is registered")
 	RunCommandAndRetry("cf api --skip-ssl-validation", 3, config.CloudFoundryConfig.ApiUrl)
 	RunCommandAndRetry("cf auth", 3, config.CloudFoundryConfig.AdminUsername, config.CloudFoundryConfig.AdminPassword)
-	RunCommandSuccessfullyWithFailureMessage(tc.Name()+" test case cannot be run: space smb-broker-space is not present", "cf target -o system -s smb-broker-space")
-	RunCommandSuccessfullyWithFailureMessage(tc.Name()+" test case cannot be run: app smbbroker is not present", "cf app smbbroker")
+	RunCommandSuccessfullyWithFailureMessage(
+		tc.Name()+" test case cannot be run: SMB service is not registered",
+		"cf service-access -e "+config.CloudFoundryConfig.SMBServiceName,
+	)
 }
 
 func (tc *SMBTestCase) BeforeBackup(config Config) {

--- a/testcases/smb_testcase.go
+++ b/testcases/smb_testcase.go
@@ -25,7 +25,7 @@ func (tc *SMBTestCase) Name() string {
 
 func (tc *SMBTestCase) CheckDeployment(config Config) {
 	By("checking if the SMB service is registered")
-	RunCommandAndRetry("cf api --skip-ssl-validation", 3, config.CloudFoundryConfig.ApiUrl)
+	RunCommandAndRetry("cf api --skip-ssl-validation", 3, config.CloudFoundryConfig.APIURL)
 	RunCommandAndRetry("cf auth", 3, config.CloudFoundryConfig.AdminUsername, config.CloudFoundryConfig.AdminPassword)
 	RunCommandSuccessfullyWithFailureMessage(
 		tc.Name()+" test case cannot be run: SMB service is not registered",
@@ -39,8 +39,8 @@ func (tc *SMBTestCase) BeforeBackup(config Config) {
 	Expect(config.CloudFoundryConfig.SMBPlanName).NotTo(BeEmpty(), "required config SMB plan name not set")
 
 	By("creating an SMB service broker and service instance")
-	RunCommandSuccessfully("cf api --skip-ssl-validation", config.CloudFoundryConfig.ApiUrl)
-	RunCommandSuccessfully("cf login --skip-ssl-validation -a", config.CloudFoundryConfig.ApiUrl,
+	RunCommandSuccessfully("cf api --skip-ssl-validation", config.CloudFoundryConfig.APIURL)
+	RunCommandSuccessfully("cf login --skip-ssl-validation -a", config.CloudFoundryConfig.APIURL,
 		"-u", config.CloudFoundryConfig.AdminUsername, "-p", config.CloudFoundryConfig.AdminPassword)
 	orgName := "acceptance-test-org-" + tc.uniqueTestID
 	spaceName := "acceptance-test-space-" + tc.uniqueTestID
@@ -52,7 +52,7 @@ func (tc *SMBTestCase) BeforeBackup(config Config) {
 	if config.CloudFoundryConfig.SMBCreateServiceBroker {
 		RunCommandSuccessfully("cf create-service-broker " + "smbbroker-drats-" + tc.uniqueTestID + " " +
 			config.CloudFoundryConfig.SMBBrokerUser + " " + config.CloudFoundryConfig.SMBBrokerPassword + " " +
-			config.CloudFoundryConfig.SMBBrokerUrl)
+			config.CloudFoundryConfig.SMBBrokerURL)
 	}
 
 	RunCommandSuccessfully("cf enable-service-access " + config.CloudFoundryConfig.SMBServiceName + " -o " + orgName)


### PR DESCRIPTION
The NFS and SMB CheckDeployment hooks relied on the default org, space and app names for their service broker apps. However, these can be configured using job properties. To avoid discovering this configuration, we check if the service has been registered instead. The service names for NFS and SMB are already configurable in DRATS.

Also:
- Improve SSH tunnel start and clean up
- Avoid mixed case for acronyms