### PR TITLE
Update test app to use Golang 1.12

### DIFF
--- a/fixtures/credhub-test-app/manifest.yml
+++ b/fixtures/credhub-test-app/manifest.yml
@@ -1,5 +1,5 @@
 ---
 applications:
 - env:
-    GOVERSION: go1.12
+    GOVERSION: go1.11
     GOPACKAGENAME: server

--- a/fixtures/credhub-test-app/manifest.yml
+++ b/fixtures/credhub-test-app/manifest.yml
@@ -1,5 +1,5 @@
 ---
 applications:
 - env:
-    GOVERSION: go1.9
+    GOVERSION: go1.12
     GOPACKAGENAME: server


### PR DESCRIPTION
Thanks for submitting a PR to DRATs.

## Checklist

Please provide the following information (and links if possible):

### [cf-deployment] What component are you testing? 

### [yes] Is the component a default component in `cf-deployment`?

### [No] Have you created a `TestCase` and added it to the list of cases to be run?

### [No] Have you added any new properties/information to all of the following:
* [ ] [integration_config.json](../ci/integration_config.json): Specifically, an `include_<testcase-name>` property
* [ ] [documentation in docs/](../docs/)
* [ ] [tasks in ci/](../ci/)
* [ ] [scripts in scripts/](../scripts/)

### [Yes, [cf-deployment develop](https://github.com/cloudfoundry/cf-deployment/tree/f38b089d215e986067d6581a4857d0e797c51e99)] Have you manually validated your `TestCase` against a deployed Cloud Foundry? If so, which version?

### [Yes, future release] Does this change rely on a particular version of `cf-deployment`?

### [N/A] Are there any optional components of Cloud Foundry that should be enabled for this new `TestCase` to succeed?  Are their presence checked for in the `CheckDeployment` method of your `TestCase`?

### [Yes, PDT] Are you available for a cross-team pair to help troubleshoot your PR?  What timezones are you based in?

### [ ] Have you submitted a pull-request to modify the `cf-deployment` [backup and restore ops files](https://github.com/cloudfoundry/cf-deployment/blob/master/operations/backup-and-restore/) to add a backup job and properties where appropriate?

## Do you have any other useful information for us?

As per [go buildpack release notes](https://github.com/cloudfoundry/go-buildpack/releases/tag/v1.8.36) they removed support for Golang 1.9.x in version version `1.8.36`.
cf-deployment drats are failing with the following error:
```
   Downloaded app package (253.2K)
   -----> Go Buildpack version 1.8.38
          **WARNING** [DEPRECATION WARNING]:
          **WARNING** Please use AppDynamics extension buildpack for Golang Application instrumentation
          **WARNING** for more details: https://docs.pivotal.io/partners/appdynamics/multibuildpack.html
   -----> Installing godep 80
          Download [https://buildpacks.cloudfoundry.org/dependencies/godep/godep-v80-linux-x64-cflinuxfs3-b60ac947.tgz]
   -----> Installing glide 0.13.2
          Download [https://buildpacks.cloudfoundry.org/dependencies/glide/glide-v0.13.2-linux-x64-cflinuxfs3-b50997e2.tgz]
   -----> Installing dep 0.5.1
          Download [https://buildpacks.cloudfoundry.org/dependencies/dep/dep-v0.5.1-linux-x64-cflinuxfs3-c2056e50.tgz]
          **ERROR** Unable to determine Go version to install: no match found for 1.9.x in [1.10.7 1.10.8 1.11.6 1.11.7 1.12.1 1.12.2]
   Failed to compile droplet: Failed to run all supply scripts: exit status 16
   Exit status 223
   Cell 82b2968a-de65-4e02-a63e-2987ce54a6b2 stopping instance a140c408-a2a6-4215-8483-6049e9e58a95
   Cell 82b2968a-de65-4e02-a63e-2987ce54a6b2 destroying container for instance a140c408-a2a6-4215-8483-6049e9e58a95
   Cell 82b2968a-de65-4e02-a63e-2987ce54a6b2 successfully destroyed container for instance a140c408-a2a6-4215-8483-6049e9e58a95
Error staging application: App staging failed in the buildpack compile phase
FAILED
```

Feel free to reach out to the Release Integration team at slack #cf-deployment or #release-integration.

Thanks!

We're on the #bbr cloudfoundry Slack channel if you need us.