### PR TITLE
Move SetDefaultEventuallyTimeout in the correct place

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -22,6 +22,8 @@ func RunDisasterRecoveryAcceptanceTests(config Config, testCases []TestCase) {
 	var err error
 
 	BeforeEach(func() {
+		SetDefaultEventuallyTimeout(config.Timeout)
+
 		fmt.Println("\nRunning test cases:")
 		for _, testCase := range testCases {
 			fmt.Println(testCase.Name())
@@ -33,8 +35,6 @@ func RunDisasterRecoveryAcceptanceTests(config Config, testCases []TestCase) {
 		}
 
 		backupRunning = false
-
-		SetDefaultEventuallyTimeout(config.Timeout)
 
 		uniqueTestID = RandomStringNumber()
 		testContext, err = NewTestContext(uniqueTestID, config.BoshConfig)


### PR DESCRIPTION
SetDefaultEventuallyTimeout was set after the TestCase.CheckDeployment
steps. This means that any CheckDeployment step could timeout if it used
an Eventually statement, and this is the case of nfs.

We probably did not hit this issue in our pipelines since we run many
testcases and not just one. If at least one testcase without an
Eventually step in the CheckDeployment would run, the test suite then
would SetDefaultEventuallyTimeout properly for the rest of the
testcases.

