### PR TITLE
Use go 1.12

### DIFF
--- a/fixtures/credhub-test-app/manifest.yml
+++ b/fixtures/credhub-test-app/manifest.yml
@@ -1,5 +1,5 @@
 ---
 applications:
 - env:
-    GOVERSION: go1.11
+    GOVERSION: go1.12
     GOPACKAGENAME: server


### PR DESCRIPTION
The go buildpack has deprecated go 1.11: https://github.com/cloudfoundry/go-buildpack/releases/tag/v1.9.1

The minimum supported version is 1.12.9

Thanks for submitting a PR to DRATs.

## Checklist

Please provide the following information (and links if possible):

### [ ] What component are you testing? 

PAS N+1

### [ ] Is the component an default component in `cf-deployment`?

N/A

### [ ] Have you created a `TestCase` and added it to the list of cases to be run?

N/A

### [ ] Have you added any new properties/information to all of the following:

N/A

### [ ] Have you manually validated your `TestCase` against a deployed Cloud Foundry? If so, which version?

We're experiencing failures in our pipelines

### [ ] Does this change rely on a particular version of `cf-deployment`?

Not that I'm aware

### [ ] Are there any optional components of Cloud Foundry that should be enabled for this new `TestCase` to succeed?  Are their presence checked for in the `CheckDeployment` method of your `TestCase`?

The Go buildpack v1.9.1+ no longer bundles Go 1.11

### [ ] Are you available for a cross-team pair to help troubleshoot your PR?  What timezones are you based in?

Absolutely. PST.

### [ ] Have you submitted a pull-request to modify the `cf-deployment` [backup and restore ops files](https://github.com/cloudfoundry/cf-deployment/blob/master/operations/backup-and-restore/) to add a backup job and properties where appropriate?

No.

## Do you have any other useful information for us?

N/A