### PR TITLE
Ensure after selective restore

### DIFF
--- a/config/env.go
+++ b/config/env.go
@@ -37,6 +37,9 @@ func FromEnv() (runner.Config, runner.TestCaseFilter) {
 	deploymentConfig.CredHubClient = os.Getenv("CF_CREDHUB_CLIENT")
 	deploymentConfig.CredHubSecret = os.Getenv("CF_CREDHUB_SECRET")
 
+	deploymentConfig.SelectiveBackup = os.Getenv("SELECTIVE_BACKUP") == "true"
+	deploymentConfig.SelectiveBackupType = os.Getenv("SELECTIVE_BACKUP_TYPE")
+
 	timeout := TimeoutFromEnv()
 
 	deleteAndRedeployCF := os.Getenv("DELETE_AND_REDEPLOY_CF") == "true"

--- a/docs/testing_with_bbl.md
+++ b/docs/testing_with_bbl.md
@@ -129,3 +129,20 @@ To also run the test case for the optional component SMB Broker, set the followi
         <td>Required to register the SMB service broker when running the SMB test case</td>
     <tr>
 </table>
+
+### DRATs with Selective Backup
+If you have deployed your cf-deployment to selectively backup blobs, set the following variables:
+<table style="width:100%">
+  <tr>
+    <th>Selective Backup Environment Variable</th>
+    <th>Usage</th>
+  </tr>
+    <tr>
+        <td>`SELECTIVE_BACKUP`</td>
+        <td>Set to "true" to run the EnsureAfterSelectiveRestore test case step</td>
+    <tr>
+    <tr>
+        <td>`SELECTIVE_BACKUP_TYPE`</td>
+        <td>set to droplets or droplets_and_packages</td>
+    <tr>
+</table>

--- a/docs/testing_with_config.md
+++ b/docs/testing_with_config.md
@@ -173,3 +173,21 @@ To also run the test case for the optional component SMB Broker, set the followi
         <td>Required to register the SMB service broker when running the SMB test case</td>
     <tr>
 </table>
+
+
+### DRATs with Selective Backup
+If you have deployed your cf-deployment to selectively backup blobs, set the following variables:
+<table style="width:100%">
+  <tr>
+    <th>Selective Backup Environment Variable</th>
+    <th>Usage</th>
+  </tr>
+    <tr>
+        <td>`selective_backup`</td>
+        <td>Set to "true" to run the EnsureAfterSelectiveRestore test case step</td>
+    <tr>
+    <tr>
+        <td>`selective_backup_type`</td>
+        <td>set to droplets or droplets_and_packages</td>
+    <tr>
+</table>

--- a/docs/testing_with_env_vars.md
+++ b/docs/testing_with_env_vars.md
@@ -177,3 +177,20 @@ To also run the test case for the optional component SMB Broker, set the followi
         <td>Required to register the SMB service broker when running the SMB test case</td>
     <tr>
 </table>
+
+### DRATs with Selective Backup
+If you have deployed your cf-deployment to selectively backup blobs, set the following variables:
+<table style="width:100%">
+  <tr>
+    <th>Selective Backup Environment Variable</th>
+    <th>Usage</th>
+  </tr>
+    <tr>
+        <td>`SELECTIVE_BACKUP`</td>
+        <td>Set to "true" to run the EnsureAfterSelectiveRestore test case step</td>
+    <tr>
+    <tr>
+        <td>`SELECTIVE_BACKUP_TYPE`</td>
+        <td>set to droplets or droplets_and_packages</td>
+    <tr>
+</table>

--- a/runner/config.go
+++ b/runner/config.go
@@ -15,6 +15,8 @@ type CloudFoundryConfig struct {
 	NFSBrokerUser                     string `json:"nfs_broker_user,omitempty"`
 	NFSBrokerPassword                 string `json:"nfs_broker_password,omitempty"`
 	NFSBrokerURL                      string `json:"nfs_broker_url,omitempty"`
+	SelectiveBackup                   bool   `json:"selective_backup,omitempty"`
+	SelectiveBackupType               string `json:"selective_backup_type,omitempty"`
 	SMBServiceName                    string `json:"smb_service_name,omitempty"`
 	SMBPlanName                       string `json:"smb_plan_name,omitempty"`
 	SMBCreateServiceBroker            bool   `json:"smb_create_service_broker,omitempty"`

--- a/runner/filter_test.go
+++ b/runner/filter_test.go
@@ -119,11 +119,12 @@ func (tc FakeTestCase) Name() string {
 	return tc.name
 }
 
-func (tc FakeTestCase) CheckDeployment(config runner.Config) {}
-func (tc FakeTestCase) BeforeBackup(config runner.Config)    {}
-func (tc FakeTestCase) AfterBackup(config runner.Config)     {}
-func (tc FakeTestCase) AfterRestore(config runner.Config)    {}
-func (tc FakeTestCase) Cleanup(config runner.Config)         {}
+func (tc FakeTestCase) CheckDeployment(config runner.Config)             {}
+func (tc FakeTestCase) BeforeBackup(config runner.Config)                {}
+func (tc FakeTestCase) AfterBackup(config runner.Config)                 {}
+func (tc FakeTestCase) EnsureAfterSelectiveRestore(config runner.Config) {}
+func (tc FakeTestCase) AfterRestore(config runner.Config)                {}
+func (tc FakeTestCase) Cleanup(config runner.Config)                     {}
 
 func testCase(name string) runner.TestCase {
 	return FakeTestCase{name: name}

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -136,6 +136,14 @@ func RunDisasterRecoveryAcceptanceTests(config Config, testCases []TestCase) {
 
 		Eventually(StatusCode(config.CloudFoundryConfig.APIURL), 5*time.Minute).Should(Equal(200))
 
+		if config.SelectiveBackup {
+			for _, testCase := range testCases {
+				By("running the EnsureAfterSelectiveRestore step for " + testCase.Name())
+				os.Setenv("CF_HOME", cfHomeDir(cfHomeTmpDir, testCase))
+				testCase.EnsureAfterSelectiveRestore(config)
+			}
+		}
+
 		By("checking state in restored environment")
 		for _, testCase := range testCases {
 			By("running the AfterRestore step for " + testCase.Name())

--- a/runner/testcase.go
+++ b/runner/testcase.go
@@ -5,6 +5,7 @@ type TestCase interface {
 	CheckDeployment(Config)
 	BeforeBackup(Config)
 	AfterBackup(Config)
+	EnsureAfterSelectiveRestore(Config)
 	AfterRestore(Config)
 	Cleanup(Config)
 }

--- a/scripts/run_acceptance_tests_local_with_config.sh
+++ b/scripts/run_acceptance_tests_local_with_config.sh
@@ -8,17 +8,6 @@ set -eu -o pipefail
 # The following params are optional
 : "${SKIP_SUITE_NAME:=""}"
 
-cleanup() {
-  rm -rf "${tmpdir}"
-
-  echo "Closing SSH tunnel..."
-  if [[ -f sshuttle.pid ]]; then
-    kill "$(cat sshuttle.pid)"
-  fi
-  rm -f sshuttle.pid
-}
-trap 'cleanup' EXIT
-
 tmpdir="$( mktemp -d /tmp/run-drats.XXXXXXXXXX )"
 
 BOSH_GW_USER=`jq -r .ssh_proxy_user ${CONFIG}`
@@ -32,13 +21,13 @@ chmod 600 "${ssh_key}"
 echo "Starting SSH tunnel, you may be prompted for your OS password..."
 sudo true # prompt for password
 sshuttle -e "ssh -i ${ssh_key} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" -r "${BOSH_GW_USER}@${BOSH_GW_HOST}" ${SSH_DESTINATION_CIDR} &
+tunnel_pid="$!"
 
-sleep 5
-
-if ! stat sshuttle.pid > /dev/null 2>&1; then
-  echo "Failed to start sshuttle daemon"
-  exit 1
-fi
+cleanup() {
+  kill "${tunnel_pid}"
+  rm -rf "${tmpdir}"
+}
+trap 'cleanup' EXIT
 
 export BBR_BUILD_PATH=$(which bbr)
 

--- a/testcases/cf_app_testcase.go
+++ b/testcases/cf_app_testcase.go
@@ -49,6 +49,8 @@ func (tc *CfAppTestCase) AfterBackup(config Config) {
 	tc.deletePushedApps(config)
 }
 
+func (tc *CfAppTestCase) EnsureAfterSelectiveRestore(config Config) {}
+
 func (tc *CfAppTestCase) AfterRestore(config Config) {
 	By("finding credentials for the deployment to restore")
 

--- a/testcases/cf_networking_testcase.go
+++ b/testcases/cf_networking_testcase.go
@@ -45,6 +45,8 @@ func (tc *CfNetworkingTestCase) AfterBackup(config Config) {
 	RunCommandSuccessfully(fmt.Sprintf("cf remove-network-policy %s --destination-app %s --port 8080 --protocol tcp", testAppName, testAppName))
 }
 
+func (tc *CfNetworkingTestCase) EnsureAfterSelectiveRestore(config Config) {}
+
 func (tc *CfNetworkingTestCase) AfterRestore(config Config) {
 	By("finding credentials for the deployment to restore")
 	session := RunCommand(fmt.Sprintf("cf network-policies"))

--- a/testcases/cf_networking_testcase.go
+++ b/testcases/cf_networking_testcase.go
@@ -11,13 +11,20 @@ import (
 )
 
 type CfNetworkingTestCase struct {
-	uniqueTestID string
-	name         string
+	uniqueTestID       string
+	name               string
+	testAppFixturePath string
+	testAppName        string
 }
 
 func NewCfNetworkingTestCase() *CfNetworkingTestCase {
 	id := RandomStringNumber()
-	return &CfNetworkingTestCase{uniqueTestID: id, name: "cf-networking"}
+	return &CfNetworkingTestCase{
+		uniqueTestID:       id,
+		name:               "cf-networking",
+		testAppFixturePath: path.Join(CurrentTestDir(), "/../fixtures/test_app/"),
+		testAppName:        fmt.Sprintf("test_app_%s", id),
+	}
 }
 
 func (tc *CfNetworkingTestCase) Name() string {
@@ -34,10 +41,8 @@ func (tc *CfNetworkingTestCase) BeforeBackup(config Config) {
 	RunCommandSuccessfully("cf create-org acceptance-test-org-" + tc.uniqueTestID)
 	RunCommandSuccessfully("cf create-space acceptance-test-space-" + tc.uniqueTestID + " -o acceptance-test-org-" + tc.uniqueTestID)
 	RunCommandSuccessfully("cf target -s acceptance-test-space-" + tc.uniqueTestID + " -o acceptance-test-org-" + tc.uniqueTestID)
-	var testAppFixturePath = path.Join(CurrentTestDir(), "/../fixtures/test_app/")
-	testAppName := fmt.Sprintf("test_app_%s", tc.uniqueTestID)
-	RunCommandSuccessfully("cf push " + testAppName + " -p " + testAppFixturePath)
-	RunCommandSuccessfully(fmt.Sprintf("cf add-network-policy %s --destination-app %s --port 8080 --protocol tcp", testAppName, testAppName))
+	RunCommandSuccessfully("cf push " + tc.testAppName + " -p " + tc.testAppFixturePath)
+	RunCommandSuccessfully(fmt.Sprintf("cf add-network-policy %s --destination-app %s --port 8080 --protocol tcp", tc.testAppName, tc.testAppName))
 }
 
 func (tc *CfNetworkingTestCase) AfterBackup(config Config) {
@@ -45,7 +50,10 @@ func (tc *CfNetworkingTestCase) AfterBackup(config Config) {
 	RunCommandSuccessfully(fmt.Sprintf("cf remove-network-policy %s --destination-app %s --port 8080 --protocol tcp", testAppName, testAppName))
 }
 
-func (tc *CfNetworkingTestCase) EnsureAfterSelectiveRestore(config Config) {}
+func (tc *CfNetworkingTestCase) EnsureAfterSelectiveRestore(config Config) {
+	By("repushing apps if restoring from a selective restore")
+	RunCommandSuccessfully("cf push " + tc.testAppName + " -p " + tc.testAppFixturePath)
+}
 
 func (tc *CfNetworkingTestCase) AfterRestore(config Config) {
 	By("finding credentials for the deployment to restore")

--- a/testcases/cf_uaa_testcase.go
+++ b/testcases/cf_uaa_testcase.go
@@ -51,6 +51,8 @@ func (tc *CfUaaTestCase) AfterBackup(config Config) {
 	Expect(result.ExitCode()).To(Equal(1))
 }
 
+func (tc *CfUaaTestCase) EnsureAfterSelectiveRestore(config Config) {}
+
 func (tc *CfUaaTestCase) AfterRestore(config Config) {
 	By("we can login again")
 	login(config, tc.testUser, tc.testPassword)

--- a/testcases/credhub_instance_creds_testcase.go
+++ b/testcases/credhub_instance_creds_testcase.go
@@ -79,6 +79,8 @@ func (tc *CfCredhubSSITestCase) AfterBackup(config Config) {
 	Expect(listResponse.Credentials).To(HaveLen(2))
 }
 
+func (tc *CfCredhubSSITestCase) EnsureAfterSelectiveRestore(config Config) {}
+
 func (tc *CfCredhubSSITestCase) AfterRestore(config Config) {
 	appResponse := Get(tc.appURL + "/list")
 	Expect(json.NewDecoder(appResponse.Body).Decode(&listResponse)).To(Succeed())

--- a/testcases/credhub_instance_creds_testcase.go
+++ b/testcases/credhub_instance_creds_testcase.go
@@ -13,18 +13,20 @@ import (
 )
 
 type CfCredhubSSITestCase struct {
-	uniqueTestID string
-	name         string
-	appName      string
-	appURL       string
+	uniqueTestID       string
+	name               string
+	appName            string
+	appURL             string
+	testAppFixturePath string
 }
 
 func NewCfCredhubSSITestCase() *CfCredhubSSITestCase {
 	id := RandomStringNumber()
 	return &CfCredhubSSITestCase{
-		uniqueTestID: id,
-		name:         "cf-credhub",
-		appName:      "app" + id,
+		uniqueTestID:       id,
+		name:               "cf-credhub",
+		appName:            "app" + id,
+		testAppFixturePath: path.Join(CurrentTestDir(), "/../fixtures/credhub-test-app"),
 	}
 }
 
@@ -48,8 +50,7 @@ func (tc *CfCredhubSSITestCase) BeforeBackup(config Config) {
 	RunCommandSuccessfully("cf create-space acceptance-test-space-" + tc.uniqueTestID + " -o acceptance-test-org-" + tc.uniqueTestID)
 	RunCommandSuccessfully("cf target -s acceptance-test-space-" + tc.uniqueTestID + " -o acceptance-test-org-" + tc.uniqueTestID)
 
-	var testAppPath = path.Join(CurrentTestDir(), "/../fixtures/credhub-test-app")
-	RunCommandSuccessfully("cf push " + "--no-start " + tc.appName + " -p " + testAppPath + " -b go_buildpack" + " -f " + testAppPath + "/manifest.yml")
+	RunCommandSuccessfully("cf push " + "--no-start " + tc.appName + " -p " + tc.testAppFixturePath + " -b go_buildpack" + " -f " + tc.testAppFixturePath + "/manifest.yml")
 	RunCommandSuccessfully("cf set-env " + tc.appName + " CREDHUB_CLIENT " + config.CloudFoundryConfig.CredHubClient + " > /dev/null")
 	RunCommandSuccessfully("cf set-env " + tc.appName + " CREDHUB_SECRET " + config.CloudFoundryConfig.CredHubSecret + " > /dev/null")
 	RunCommandSuccessfully("cf start " + tc.appName)
@@ -79,7 +80,12 @@ func (tc *CfCredhubSSITestCase) AfterBackup(config Config) {
 	Expect(listResponse.Credentials).To(HaveLen(2))
 }
 
-func (tc *CfCredhubSSITestCase) EnsureAfterSelectiveRestore(config Config) {}
+func (tc *CfCredhubSSITestCase) EnsureAfterSelectiveRestore(config Config) {
+	RunCommandSuccessfully("cf push " + "--no-start " + tc.appName + " -p " + tc.testAppFixturePath + " -b go_buildpack" + " -f " + tc.testAppFixturePath + "/manifest.yml")
+	RunCommandSuccessfully("cf set-env " + tc.appName + " CREDHUB_CLIENT " + config.CloudFoundryConfig.CredHubClient + " > /dev/null")
+	RunCommandSuccessfully("cf set-env " + tc.appName + " CREDHUB_SECRET " + config.CloudFoundryConfig.CredHubSecret + " > /dev/null")
+	RunCommandSuccessfully("cf start " + tc.appName)
+}
 
 func (tc *CfCredhubSSITestCase) AfterRestore(config Config) {
 	appResponse := Get(tc.appURL + "/list")

--- a/testcases/nfs_testcase.go
+++ b/testcases/nfs_testcase.go
@@ -67,7 +67,10 @@ func (tc *NFSTestCase) AfterBackup(config Config) {
 	RunCommandSuccessfully("cf delete-service " + tc.instanceName + " -f")
 }
 
-func (tc *NFSTestCase) EnsureAfterSelectiveRestore(config Config) {}
+func (tc *NFSTestCase) EnsureAfterSelectiveRestore(config Config) {
+	By("repushing apps if restoring from a selective restore")
+	RunCommandSuccessfully("cf push dratsApp --docker-image docker/httpd --no-start --random-route")
+}
 
 func (tc *NFSTestCase) AfterRestore(config Config) {
 	By("re-binding the NFS service instance after restore")

--- a/testcases/nfs_testcase.go
+++ b/testcases/nfs_testcase.go
@@ -67,6 +67,8 @@ func (tc *NFSTestCase) AfterBackup(config Config) {
 	RunCommandSuccessfully("cf delete-service " + tc.instanceName + " -f")
 }
 
+func (tc *NFSTestCase) EnsureAfterSelectiveRestore(config Config) {}
+
 func (tc *NFSTestCase) AfterRestore(config Config) {
 	By("re-binding the NFS service instance after restore")
 	time.Sleep(5 * time.Minute)

--- a/testcases/router_group_testcase.go
+++ b/testcases/router_group_testcase.go
@@ -89,6 +89,8 @@ func (tc *CfRouterGroupTestCase) AfterBackup(config Config) {
 	Expect(err).NotTo(HaveOccurred())
 }
 
+func (tc *CfRouterGroupTestCase) EnsureAfterSelectiveRestore(config Config) {}
+
 // AfterRestore is run after the bbr is done restoring the database.
 // The function compares the post restore router group table with
 // pre restore router group table.

--- a/testcases/smb_testcase.go
+++ b/testcases/smb_testcase.go
@@ -66,6 +66,7 @@ func (tc *SMBTestCase) AfterBackup(config Config) {
 	By("deleting the SMB service instance after backup")
 	RunCommandSuccessfully("cf delete-service " + tc.instanceName + " -f")
 }
+func (tc *SMBTestCase) EnsureAfterSelectiveRestore(config Config) {}
 
 func (tc *SMBTestCase) AfterRestore(config Config) {
 	By("re-binding the SMB service instance after restore")

--- a/testcases/smb_testcase.go
+++ b/testcases/smb_testcase.go
@@ -66,7 +66,10 @@ func (tc *SMBTestCase) AfterBackup(config Config) {
 	By("deleting the SMB service instance after backup")
 	RunCommandSuccessfully("cf delete-service " + tc.instanceName + " -f")
 }
-func (tc *SMBTestCase) EnsureAfterSelectiveRestore(config Config) {}
+func (tc *SMBTestCase) EnsureAfterSelectiveRestore(config Config) {
+	By("repushing apps if restoring from a selective restore")
+	RunCommandSuccessfully("cf push dratsApp --docker-image docker/httpd --no-start --random-route")
+}
 
 func (tc *SMBTestCase) AfterRestore(config Config) {
 	By("re-binding the SMB service instance after restore")

--- a/testcases/uptime_testcase.go
+++ b/testcases/uptime_testcase.go
@@ -59,6 +59,8 @@ func (tc *AppUptimeTestCase) AfterBackup(config Config) {
 	Expect(<-tc.valueAPIWasDown).To(BeTrue(), "expected api to be down, but it isn't")
 }
 
+func (tc *AppUptimeTestCase) EnsureAfterSelectiveRestore(config Config) {}
+
 func (tc *AppUptimeTestCase) AfterRestore(config Config) {
 
 }


### PR DESCRIPTION
Story here: https://www.pivotaltracker.com/story/show/168922913

PR pipeline now skips backing up droplets and packages and this PR adds the `EnsureAfterSelectiveRestore` step to all testcases so that testcases using test apps will be unaffected.
This involves repushing these apps before the `AfterRestore` step is run to ensure apps are up and running again despite missing blobs.