### PR TITLE
Remove sleeps to compensate for routing-release caching 404s

### DIFF
--- a/testcases/nfs_testcase.go
+++ b/testcases/nfs_testcase.go
@@ -2,8 +2,6 @@ package testcases
 
 import (
 	"fmt"
-	"time"
-
 	. "github.com/cloudfoundry-incubator/disaster-recovery-acceptance-tests/runner"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -74,7 +72,6 @@ func (tc *NFSTestCase) EnsureAfterSelectiveRestore(config Config) {
 
 func (tc *NFSTestCase) AfterRestore(config Config) {
 	By("re-binding the NFS service instance after restore")
-	time.Sleep(5 * time.Minute)
 	RunCommandSuccessfully("cf bind-service dratsApp " + tc.instanceName + ` -c '{"uid":5000,"gid":5000}'`)
 }
 

--- a/testcases/smb_testcase.go
+++ b/testcases/smb_testcase.go
@@ -2,8 +2,6 @@ package testcases
 
 import (
 	"fmt"
-	"time"
-
 	. "github.com/cloudfoundry-incubator/disaster-recovery-acceptance-tests/runner"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -73,7 +71,6 @@ func (tc *SMBTestCase) EnsureAfterSelectiveRestore(config Config) {
 
 func (tc *SMBTestCase) AfterRestore(config Config) {
 	By("re-binding the SMB service instance after restore")
-	time.Sleep(5 * time.Minute)
 	RunCommandSuccessfully("cf bind-service dratsApp " + tc.instanceName + ` -c '{"username":"someuser","password":"somepass"}'`)
 }
 


### PR DESCRIPTION
Story here: https://www.pivotaltracker.com/story/show/168922913

In routing-release `0.189.0`, they fixed a bug where 404s were being cached resulting in downed routes after restores. We introduced sleeps in order to wait for the cache to be cleared. Now that cf-d consumes the fix, we can remove them