### PR TITLE
Enable increasing default CF_DIAL_TIMEOUT

### DIFF
--- a/ci/drats-with-integration-config/task.yml
+++ b/ci/drats-with-integration-config/task.yml
@@ -13,6 +13,7 @@ inputs:
 
 params:
   CONFIG_FILE_PATH: drats_integration_config.json
+  CF_DIAL_TIMEOUT:
 
 run:
   path: src/github.com/cloudfoundry-incubator/disaster-recovery-acceptance-tests/ci/drats-with-integration-config/task.sh

--- a/testcases/router_group_testcase.go
+++ b/testcases/router_group_testcase.go
@@ -2,6 +2,7 @@ package testcases
 
 import (
 	"strings"
+	"time"
 
 	routing_api "code.cloudfoundry.org/routing-api"
 
@@ -55,7 +56,7 @@ func (tc *CfRouterGroupTestCase) BeforeBackup(config Config) {
 	token := loginAndGetToken(config)
 	By("Creating a pre-backup router group backup")
 	var err error
-
+	time.Sleep(15 * time.Second)
 	tc.routingAPIClient = routing_api.NewClient(config.CloudFoundryConfig.APIURL, true)
 	tc.routerGroupsPreBackup, err = tc.readRouterGroups(token)
 	Expect(err).NotTo(HaveOccurred())
@@ -101,6 +102,7 @@ func (tc *CfRouterGroupTestCase) AfterRestore(config Config) {
 	token := refreshToken()
 
 	By("Taking a snapshot of restored table and comparing it with the pre-backup table")
+	time.Sleep(15 * time.Second)
 	routerGroupsPostRestore, err := tc.readRouterGroups(token)
 	Expect(err).NotTo(HaveOccurred())
 	Expect(routerGroupsPostRestore).To(ConsistOf(tc.routerGroupsPreBackup))


### PR DESCRIPTION
We are experiencing high failure rates in our tests. This was determined to be due to the default CF_DIAL_TIMEOUT value of 1 second to be too short for our network setup.

This param allows users to amend the default timeout value.