### PR TITLE
Add exponential backoff to router_group call

### DIFF
--- a/testcases/router_group_testcase.go
+++ b/testcases/router_group_testcase.go
@@ -134,7 +134,7 @@ func (tc *CfRouterGroupTestCase) readRouterGroups(token string) (models.RouterGr
 		if err != nil {
 			switch err.(type) {
 			case *url.Error:
-				time.Sleep(1 * time.Second)
+				time.Sleep(time.Duration(retries*retries) * time.Second)
 				response, err = tc.routingAPIClient.RouterGroups()
 			default:
 				break


### PR DESCRIPTION
Still seeing intermittent failures on GET request to router_groups. Adding exponential backoff to try and mitigate this issue.