### PR TITLE
CI: Remove filter for cf-deployment resource

### DIFF
--- a/ci/pipelines/drats/pipeline.yml
+++ b/ci/pipelines/drats/pipeline.yml
@@ -29,7 +29,6 @@ resources:
   source:
     uri: https://github.com/cloudfoundry/cf-deployment.git
     branch: main
-    tag_filter: v13.*
 
 - name: disaster-recovery-acceptance-tests
   type: pull-request


### PR DESCRIPTION
- test on latest to discover if drats works on latest cf
- will update this pr to instead document why this resource pinning is
  needed

Signed-off-by: Neil Hickey <nhickey@vmware.com>