### PR TITLE
Update router group testcase port type

### DIFF
--- a/testcases/router_group_testcase.go
+++ b/testcases/router_group_testcase.go
@@ -83,7 +83,7 @@ func (tc *CfRouterGroupTestCase) AfterBackup(config Config) {
 		Guid:            "RandomTestGUID" + "_" + RandomStringNumber(),
 		Name:            "RandomTestName" + "_" + RandomStringNumber(),
 		Type:            "tcp",
-		ReservablePorts: "2000-4000",
+		ReservablePorts: "2822 2825 3457",
 	}
 
 	cleanupRouterGroups = func() error { return tc.routingAPIClient.DeleteRouterGroup(routerGroupEntry) }

--- a/testcases/router_group_testcase.go
+++ b/testcases/router_group_testcase.go
@@ -83,7 +83,7 @@ func (tc *CfRouterGroupTestCase) AfterBackup(config Config) {
 		Guid:            "RandomTestGUID" + "_" + RandomStringNumber(),
 		Name:            "RandomTestName" + "_" + RandomStringNumber(),
 		Type:            "tcp",
-		ReservablePorts: "2822 2825 3457",
+		ReservablePorts: "1024-2047",
 	}
 
 	cleanupRouterGroups = func() error { return tc.routingAPIClient.DeleteRouterGroup(routerGroupEntry) }


### PR DESCRIPTION
## Checklist

### [X] What component are you testing? 
Routing-api

### [X] Is the component a default component in `cf-deployment`?
Yes.

### [X] Have you created a `TestCase` and added it to the list of cases to be run?
N/A

### [X] Have you added any new properties/information to all of the following:
* [ ] [integration_config.json](../ci/integration_config.json): Specifically, an `include_<testcase-name>` property
* [ ] [documentation in docs/](../docs/)
* [ ] [tasks in ci/](../ci/)
* [ ] [scripts in scripts/](../scripts/)
N/A

### [X] Have you manually validated your `TestCase` against a deployed Cloud Foundry? If so, which version?
Latest cf-d, v16.14.0.

### [X] Does this change rely on a particular version of `cf-deployment`?
No

### [X] Are there any optional components of Cloud Foundry that should be enabled for this new `TestCase` to succeed?  Are their presence checked for in the `CheckDeployment` method of your `TestCase`?
No

### [X] Are you available for a cross-team pair to help troubleshoot your PR?  What timezones are you based in?
Yes. Eastern. 

### [X] Have you submitted a pull-request to modify the `cf-deployment` [backup and restore ops files](https://github.com/cloudfoundry/cf-deployment/blob/master/operations/backup-and-restore/) to add a backup job and properties where appropriate?
N/A

## Do you have any other useful information for us?
Some of the ports originally used are ports that are reserved for system components. According to docs, people were never supposed to use the range you provided. In the past we never prevented people from using bad ranges that would really, really, break the tcp router. In a new bug fix we are preventing them from using the range. See more (including invalid ports) [here](https://github.com/cloudfoundry/routing-release/pull/202).

We're on the #bbr cloudfoundry Slack channel if you need us.