### PR TITLE
Read CH app path from env

### DIFF
--- a/testcases/credhub_instance_creds_testcase.go
+++ b/testcases/credhub_instance_creds_testcase.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"path"
 	"strings"
 
@@ -22,12 +23,23 @@ type CfCredhubSSITestCase struct {
 
 func NewCfCredhubSSITestCase() *CfCredhubSSITestCase {
 	id := RandomStringNumber()
+
+  credhubAppPath, appPathPresent := os.LookupEnv("CREDHUB_APP_PATH") 
+
+  if no(appPathPresent) {
+    credhubAppPath = path.Join(CurrentTestDir(), "/../fixtures/credhub-test-app")
+  }
+
 	return &CfCredhubSSITestCase{
 		uniqueTestID:       id,
 		name:               "cf-credhub",
 		appName:            "app" + id,
-		testAppFixturePath: path.Join(CurrentTestDir(), "/../fixtures/credhub-test-app"),
+		testAppFixturePath: credhubAppPath,
 	}
+}
+
+func no(b bool) bool {
+  return ! b
 }
 
 var listResponse struct {


### PR DESCRIPTION
This PR allows the Crehub app path to be injected through the `CREDHUB_APP_PATH` environment variable.

If no new path is injected, the current behaviour will resume.

This can be handy in other projects like `p-drats` what want to use test cases defined but have a hard time accessing `fixtures/` from this repo.