### PR TITLE
Update CF Networking tests to run with CF CLI v7

### DIFF
--- a/ci/integration_config.json
+++ b/ci/integration_config.json
@@ -32,5 +32,6 @@
   "include_cf-routing": true,
   "include_app-uptime": true,
   "include_cf-nfsbroker": false,
-  "include_cf-smbbroker": false
+  "include_cf-smbbroker": false,
+  "selective_backup": true
 }

--- a/ci/tasks/update-integration-config/task.sh
+++ b/ci/tasks/update-integration-config/task.sh
@@ -40,7 +40,6 @@ smb_broker_password=$(get_password_from_credhub smb-broker-password || echo "")
 smb_broker_url="http://smbbroker.${SYSTEM_DOMAIN}"
 credhub_client_name="${CREDHUB_CLIENT}"
 credhub_client_secret="${CREDHUB_SECRET}"
-selective_backup=true
 
 configs=( cf_deployment_name
         cf_api_url
@@ -65,8 +64,7 @@ configs=( cf_deployment_name
         smb_broker_password
         smb_broker_url
         credhub_client_name
-        credhub_client_secret
-        selective_backup )
+        credhub_client_secret )
 
 integration_config="$(cat "integration-configs/${INTEGRATION_CONFIG_FILE_PATH}")"
 

--- a/ci/tasks/update-integration-config/task.sh
+++ b/ci/tasks/update-integration-config/task.sh
@@ -40,6 +40,7 @@ smb_broker_password=$(get_password_from_credhub smb-broker-password || echo "")
 smb_broker_url="http://smbbroker.${SYSTEM_DOMAIN}"
 credhub_client_name="${CREDHUB_CLIENT}"
 credhub_client_secret="${CREDHUB_SECRET}"
+selective_backup=true
 
 configs=( cf_deployment_name
         cf_api_url
@@ -64,7 +65,8 @@ configs=( cf_deployment_name
         smb_broker_password
         smb_broker_url
         credhub_client_name
-        credhub_client_secret )
+        credhub_client_secret
+        selective_backup )
 
 integration_config="$(cat "integration-configs/${INTEGRATION_CONFIG_FILE_PATH}")"
 

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -24,6 +24,9 @@ func RunDisasterRecoveryAcceptanceTests(config Config, testCases []TestCase) {
 	BeforeEach(func() {
 		SetDefaultEventuallyTimeout(config.Timeout)
 
+		fmt.Println("\nCF CLI version:")
+		RunCommandSuccessfully("cf", "version")
+
 		fmt.Println("\nRunning test cases:")
 		for _, testCase := range testCases {
 			fmt.Println(testCase.Name())

--- a/testcases/cf_app_testcase.go
+++ b/testcases/cf_app_testcase.go
@@ -59,7 +59,7 @@ func (tc *CfAppTestCase) BeforeBackup(config Config) {
 }
 
 func (tc *CfAppTestCase) AfterBackup(config Config) {
-	RunCommandSuccessfully("cf delete -f" + tc.deletedAppName)
+	RunCommandSuccessfully("cf delete -f " + tc.deletedAppName)
 	RunCommandSuccessfully("cf start " + tc.stoppedAppName)
 	RunCommandSuccessfully("cf stop " + tc.runningAppName)
 }

--- a/testcases/cf_app_testcase.go
+++ b/testcases/cf_app_testcase.go
@@ -59,7 +59,7 @@ func (tc *CfAppTestCase) BeforeBackup(config Config) {
 }
 
 func (tc *CfAppTestCase) AfterBackup(config Config) {
-	RunCommandSuccessfully("cf delete " + tc.deletedAppName)
+	RunCommandSuccessfully("cf delete -f" + tc.deletedAppName)
 	RunCommandSuccessfully("cf start " + tc.stoppedAppName)
 	RunCommandSuccessfully("cf stop " + tc.runningAppName)
 }

--- a/testcases/cf_networking_testcase.go
+++ b/testcases/cf_networking_testcase.go
@@ -42,12 +42,12 @@ func (tc *CfNetworkingTestCase) BeforeBackup(config Config) {
 	RunCommandSuccessfully("cf create-space acceptance-test-space-" + tc.uniqueTestID + " -o acceptance-test-org-" + tc.uniqueTestID)
 	RunCommandSuccessfully("cf target -s acceptance-test-space-" + tc.uniqueTestID + " -o acceptance-test-org-" + tc.uniqueTestID)
 	RunCommandSuccessfully("cf push " + tc.testAppName + " -p " + tc.testAppFixturePath)
-	RunCommandSuccessfully(fmt.Sprintf("cf add-network-policy %s --destination-app %s --port 8080 --protocol tcp", tc.testAppName, tc.testAppName))
+	RunCommandSuccessfully(fmt.Sprintf("cf add-network-policy %s %s --port 8080 --protocol tcp", tc.testAppName, tc.testAppName))
 }
 
 func (tc *CfNetworkingTestCase) AfterBackup(config Config) {
 	testAppName := fmt.Sprintf("test_app_%s", tc.uniqueTestID)
-	RunCommandSuccessfully(fmt.Sprintf("cf remove-network-policy %s --destination-app %s --port 8080 --protocol tcp", testAppName, testAppName))
+	RunCommandSuccessfully(fmt.Sprintf("cf remove-network-policy %s %s --port 8080 --protocol tcp", testAppName, testAppName))
 }
 
 func (tc *CfNetworkingTestCase) EnsureAfterSelectiveRestore(config Config) {


### PR DESCRIPTION
This PR updated the CF Networking tests to run with v7 of the CF CLI, which has a backwards-incompatible change in the `add-network-policy` and `remove-network-policy` commands. Unfortunately, this breaks compatibility with v6 of the CLI.

I also added a printout of the CF CLI version when the tests are run to aid with future debugging of similar issues.