### PR TITLE
fix: enable diego_docker feature flag

### DIFF
--- a/testcases/nfs_testcase.go
+++ b/testcases/nfs_testcase.go
@@ -46,6 +46,7 @@ func (tc *NFSTestCase) BeforeBackup(config Config) {
 	RunCommandSuccessfully("cf create-org " + orgName)
 	RunCommandSuccessfully("cf create-space " + spaceName + " -o " + orgName)
 	RunCommandSuccessfully("cf target -o " + orgName + " -s " + spaceName)
+	RunCommandSuccessfully("cf enable-feature-flag diego_docker")
 	RunCommandSuccessfully("cf push dratsApp --docker-image docker/httpd --no-start --random-route")
 
 	if config.CloudFoundryConfig.NFSCreateServiceBroker {


### PR DESCRIPTION
The `diego_docker` feature flag controls whether an app developer can push docker images. It's also disabled by default.

This change ensures the feature flag is enabled before trying to push a docker image.