### PR TITLE
Remove the GOVERSION env var from credhub-test-app

### DIFF
--- a/fixtures/credhub-test-app/manifest.yml
+++ b/fixtures/credhub-test-app/manifest.yml
@@ -1,5 +1,4 @@
 ---
 applications:
 - env:
-    GOVERSION: go1.15
     GOPACKAGENAME: server


### PR DESCRIPTION
Thanks for submitting a PR to DRATs.

## Checklist

Please provide the following information (and links if possible):

### [x] What component are you testing?
cf-deployment

### [x] Is the component an default component in `cf-deployment`?
See above. ;)

### [x] Have you created a `TestCase` and added it to the list of cases to be run?
N/A

### [x] Have you added any new properties/information to all of the following:
N/A

### [x] Have you manually validated your `TestCase` against a deployed Cloud Foundry? If so, which version?
https://github.com/cloudfoundry/cf-deployment/tree/de0b693272da6879e9952485951f5068b0c794a0 (HEAD of develop as of the time of writing)

### [x] Does this change rely on a particular version of `cf-deployment`?
New versions of the Go buildpack (v1.9.35+) do not include Go v1.15.

### [x] Are there any optional components of Cloud Foundry that should be enabled for this new `TestCase` to succeed?  Are their presence checked for in the `CheckDeployment` method of your `TestCase`?
N/A

### [x] Are you available for a cross-team pair to help troubleshoot your PR?  What timezones are you based in?
Yes. I am in the US Pacific timezone.

### [x] Have you submitted a pull-request to modify the `cf-deployment` [backup and restore ops files](https://github.com/cloudfoundry/cf-deployment/blob/master/operations/backup-and-restore/) to add a backup job and properties where appropriate?
N/A

## Do you have any other useful information for us?

We're on the #bbr cloudfoundry Slack channel if you need us.